### PR TITLE
Tr/viz

### DIFF
--- a/pate.cabal
+++ b/pate.cabal
@@ -123,6 +123,7 @@ executable pate-exec
                        ansi-wl-pprint,
                        lumberjack,
                        threepenny-gui >= 0.9 && < 0.10,
+                       language-c >= 0.9 && < 0.10,
                        parameterized-utils,
                        macaw-ppc,
                        macaw-ppc-symbolic,

--- a/src/Pate/Event.hs
+++ b/src/Pate/Event.hs
@@ -9,6 +9,7 @@ module Pate.Event (
 import qualified Data.Macaw.Discovery as MD
 import qualified Data.Time as TM
 
+import qualified Pate.Binary as PB
 import qualified Pate.Types as PT
 
 -- | The macaw blocks relevant for a given code address
@@ -25,3 +26,4 @@ data EquivalenceResult arch = Equivalent
 -- verification successes and failures that can be streamed to the user.
 data Event arch where
   CheckedEquivalence :: Blocks arch -> Blocks arch -> EquivalenceResult arch -> TM.NominalDiffTime -> Event arch
+  LoadedBinaries :: (PB.LoadedELF arch, PT.ParsedFunctionMap arch) -> (PB.LoadedELF arch, PT.ParsedFunctionMap arch) -> Event arch

--- a/src/Pate/Verification.hs
+++ b/src/Pate/Verification.hs
@@ -113,6 +113,8 @@ verifyPairs logAction elf elf' blockMap dcfg pPairs = do
   (mainO, pfmO)  <- runDiscovery elf
   (mainP, pfmP) <- runDiscovery elf'
 
+  liftIO $ LJ.writeLog logAction (PE.LoadedBinaries (elf, pfmO) (elf', pfmP))
+
   Some gen' <- liftIO N.newIONonceGenerator
   let pfeats = W4PF.useBitvectors .|. W4PF.useSymbolicArrays
   CBO.withYicesOnlineBackend W4B.FloatRealRepr gen' CBO.NoUnsatFeatures pfeats $ \sym -> do

--- a/tests/ppc/Makefile
+++ b/tests/ppc/Makefile
@@ -3,7 +3,10 @@
 CC=powerpc64-linux-gnu-gcc
 OD=powerpc64-linux-gnu-objdump
 
-all: $(patsubst %c,%exe,$(wildcard *.c))
+all: $(patsubst %c,%exe,$(wildcard *.c)) $(patsubst %c,%i,$(wildcard *.c))
+
+%.i: %.c
+	$(CC) -fno-stack-protector -nostdlib $< -E -o $@
 
 %.exe: %.s
 	$(CC) -fno-stack-protector -nostdlib $< -o $@

--- a/tools/pate/Interactive.hs
+++ b/tools/pate/Interactive.hs
@@ -170,8 +170,9 @@ showBlockPairDetail st detailDiv (PE.Blocks (PT.ConcreteAddress origAddr) opbs) 
   return ()
   where
     renderAddr label addr = TP.string (label ++ " (" ++ show addr ++ ")")
-    renderCode pbs = TP.code #+ [TP.pre # TP.set TP.text (renderBlocks pbs)]
-    renderBlocks pbs = show (PPL.vcat (map PPL.pretty pbs))
+    renderCode pbs = TP.code #+ [ TP.pre # TP.set TP.text (show (PPL.pretty pb)) #. "basic-block"
+                                | pb <- pbs
+                                ]
 
 renderFunctionName :: (PB.ArchConstraints arch)
                    => State arch

--- a/tools/pate/Interactive.hs
+++ b/tools/pate/Interactive.hs
@@ -189,8 +189,9 @@ renderSource st getSource origAddr = fromMaybe [] $ do
   let sname = UTF8.toString (UTF8.fromRep bname)
   LC.CTranslUnit decls _ <- getSource <$> st ^. sources
   fundef <- F.find (matchingFunctionName sname) decls
-  return [ TP.code #+ [ TP.pre # TP.set TP.text (show (LC.pretty fundef)) ] ]
+  return [ TP.code #+ [ TP.pre # TP.set TP.text (show (LC.pretty fundef)) #. "source-listing" ] ]
 
+-- | Find the declaration matching the given function name
 matchingFunctionName :: String -> LC.CExternalDeclaration LC.NodeInfo -> Bool
 matchingFunctionName sname def =
   case def of

--- a/tools/pate/Interactive.hs
+++ b/tools/pate/Interactive.hs
@@ -135,7 +135,7 @@ renderConsole r detailDiv = do
 renderEvent :: (MC.ArchConstraints arch) => TP.Element -> PE.Event arch -> TP.UI TP.Element
 renderEvent detailDiv evt =
   case evt of
-    PE.CheckedEquivalence ob@(PE.Blocks origAddr _) pb@(PE.Blocks patchedAddr _) res duration -> do
+    PE.CheckedEquivalence ob@(PE.Blocks (PT.ConcreteAddress origAddr) _) pb@(PE.Blocks (PT.ConcreteAddress patchedAddr) _) res duration -> do
       blockLink <- TP.a # TP.set TP.text (show origAddr)
                         # TP.set TP.href ("#" ++ show origAddr)
       TP.on TP.click blockLink (showBlockPairDetail detailDiv ob pb)

--- a/tools/pate/Interactive.hs
+++ b/tools/pate/Interactive.hs
@@ -11,20 +11,23 @@ module Interactive (
   ) where
 
 import qualified Control.Concurrent as CC
+import           Control.Lens ( (^.), (%~), (&), (.~) )
 import qualified Control.Lens as L
-import           Control.Lens ( (^.), (%~), (&) )
 import           Control.Monad ( void )
 import           Control.Monad.IO.Class ( liftIO )
 import qualified Data.FileEmbed as DFE
 import qualified Data.IORef as IOR
 import qualified Data.Map.Strict as Map
+import           Data.Maybe ( fromMaybe )
 import qualified Data.String.UTF8 as UTF8
-import qualified Graphics.UI.Threepenny as TP
 import           Graphics.UI.Threepenny ( (#), (#+), (#.) )
+import qualified Graphics.UI.Threepenny as TP
 import qualified Text.PrettyPrint.ANSI.Leijen as PPL
 
+import qualified Data.Macaw.BinaryLoader as MBL
 import qualified Data.Macaw.CFG as MC
 
+import qualified Pate.Binary as PB
 import qualified Pate.Event as PE
 import qualified Pate.Types as PT
 
@@ -56,6 +59,9 @@ consumeEvents chan r0 = do
     Nothing -> return ()
     Just evt -> do
       case evt of
+        PE.LoadedBinaries (oelf, omap) (pelf, pmap) -> do
+          IOR.atomicModifyIORef' (stateRef r0) $ \s -> (s & originalBinary .~ Just (oelf, omap)
+                                                          & patchedBinary .~ Just (pelf, pmap), ())
         PE.CheckedEquivalence origBlock@(PE.Blocks addr _) patchedBlock res duration -> do
           let et = EquivalenceTest origBlock patchedBlock duration
           case res of
@@ -80,12 +86,12 @@ addRecent n elt elts = elt : take (n - 1) elts
 
 -- | Start a persistent interface for the user to inspect data coming out of the
 -- verifier
-startInterface :: (MC.ArchConstraints arch) => StateRef arch -> IO ()
+startInterface :: (PB.ArchConstraints arch) => StateRef arch -> IO ()
 startInterface r = do
   let uiConf = TP.defaultConfig
   TP.startGUI uiConf (uiSetup r)
 
-uiSetup :: (MC.ArchConstraints arch) => StateRef arch -> TP.Window -> TP.UI ()
+uiSetup :: (PB.ArchConstraints arch) => StateRef arch -> TP.Window -> TP.UI ()
 uiSetup r wd = do
   st0 <- liftIO $ IOR.readIORef (stateRef r)
   void $ return wd # TP.set TP.title "PATE Verifier"
@@ -103,7 +109,7 @@ uiSetup r wd = do
   void $ liftIO $ TP.register (stateChangeEvent r) (updateConsole r wd consoleDiv summaryDiv detailDiv)
   return ()
 
-updateConsole :: (MC.ArchConstraints arch)
+updateConsole :: (PB.ArchConstraints arch)
               => StateRef arch
               -> TP.Window
               -> TP.Element
@@ -124,21 +130,22 @@ updateConsole r wd consoleDiv summaryDiv detailDiv () = do
 --
 -- The most recent event will be on the bottom (as in a normal scrolling
 -- terminal), which requires us to reverse the events list
-renderConsole :: (MC.ArchConstraints arch)
+renderConsole :: (PB.ArchConstraints arch)
               => StateRef arch
               -> TP.Element
               -> TP.UI TP.Element
 renderConsole r detailDiv = do
   state <- liftIO $ IOR.readIORef (stateRef r)
-  TP.ul #+ (map (\evt -> TP.li #+ [renderEvent detailDiv evt]) (reverse (state ^. recentEvents)))
+  TP.ul #+ (map (\evt -> TP.li #+ [renderEvent state detailDiv evt]) (reverse (state ^. recentEvents)))
 
-renderEvent :: (MC.ArchConstraints arch) => TP.Element -> PE.Event arch -> TP.UI TP.Element
-renderEvent detailDiv evt =
+renderEvent :: (PB.ArchConstraints arch) => State arch -> TP.Element -> PE.Event arch -> TP.UI TP.Element
+renderEvent st detailDiv evt =
   case evt of
+    PE.LoadedBinaries {} -> TP.string "Loaded original and patched binaries"
     PE.CheckedEquivalence ob@(PE.Blocks (PT.ConcreteAddress origAddr) _) pb@(PE.Blocks (PT.ConcreteAddress patchedAddr) _) res duration -> do
       blockLink <- TP.a # TP.set TP.text (show origAddr)
                         # TP.set TP.href ("#" ++ show origAddr)
-      TP.on TP.click blockLink (showBlockPairDetail detailDiv ob pb)
+      TP.on TP.click blockLink (showBlockPairDetail st detailDiv ob pb)
       TP.span #+ [ TP.string "Checking original block at "
                  , return blockLink
                  , TP.string " against patched block at "
@@ -148,14 +155,15 @@ renderEvent detailDiv evt =
                  ]
 
 -- | Show the original block at the given address (as well as its corresponding patched block)
-showBlockPairDetail :: (MC.ArchConstraints arch)
-                    => TP.Element
+showBlockPairDetail :: (PB.ArchConstraints arch)
+                    => State arch
+                    -> TP.Element
                     -> PE.Blocks arch
                     -> PE.Blocks arch
                     -> a
                     -> TP.UI ()
-showBlockPairDetail detailDiv (PE.Blocks (PT.ConcreteAddress origAddr) opbs) (PE.Blocks (PT.ConcreteAddress patchedAddr) ppbs) _ = do
-  g <- TP.grid [ [renderAddr "Original Code" origAddr, renderAddr "Patched Code" patchedAddr]
+showBlockPairDetail st detailDiv (PE.Blocks (PT.ConcreteAddress origAddr) opbs) (PE.Blocks (PT.ConcreteAddress patchedAddr) ppbs) _ = do
+  g <- TP.grid [ concat [[renderAddr "Original Code" origAddr, renderAddr "Patched Code" patchedAddr], renderFunctionName st origAddr]
                , [renderCode opbs, renderCode ppbs]
                ]
   void $ return detailDiv # TP.set TP.children [g]
@@ -164,6 +172,16 @@ showBlockPairDetail detailDiv (PE.Blocks (PT.ConcreteAddress origAddr) opbs) (PE
     renderAddr label addr = TP.string (label ++ " (" ++ show addr ++ ")")
     renderCode pbs = TP.code #+ [TP.pre # TP.set TP.text (renderBlocks pbs)]
     renderBlocks pbs = show (PPL.vcat (map PPL.pretty pbs))
+
+renderFunctionName :: (PB.ArchConstraints arch)
+                   => State arch
+                   -> MC.MemAddr (MC.ArchAddrWidth arch)
+                   -> [TP.UI TP.Element]
+renderFunctionName st origAddr = fromMaybe [] $ do
+  (lelf, _) <- st ^. originalBinary
+  bname <- MBL.symbolFor (PB.loadedBinary lelf) origAddr
+  let sname = UTF8.toString (UTF8.fromRep bname)
+  return [TP.string ("(Function: " ++ sname ++ ")")]
 
 renderEquivalenceResult :: PE.EquivalenceResult arch -> TP.UI TP.Element
 renderEquivalenceResult res =

--- a/tools/pate/Interactive/State.hs
+++ b/tools/pate/Interactive/State.hs
@@ -8,13 +8,16 @@ module Interactive.State (
   successful,
   indeterminate,
   failure,
-  recentEvents
+  recentEvents,
+  originalBinary,
+  patchedBinary
   ) where
 
 import qualified Control.Lens as L
 import qualified Data.Map.Strict as Map
 import qualified Data.Time as TM
 
+import qualified Pate.Binary as PB
 import qualified Pate.Event as PE
 import qualified Pate.Types as PT
 
@@ -34,6 +37,8 @@ data State arch =
         , _failure :: Map.Map (PT.ConcreteAddress arch) (Failure arch)
         , _recentEvents :: [PE.Event arch]
         -- ^ The N most recent events (most recent first), to be shown in the console
+        , _originalBinary :: Maybe (PB.LoadedELF arch, PT.ParsedFunctionMap arch)
+        , _patchedBinary :: Maybe (PB.LoadedELF arch, PT.ParsedFunctionMap arch)
         }
 
 $(L.makeLenses 'State)
@@ -43,4 +48,6 @@ emptyState = State { _successful = Map.empty
                    , _indeterminate = Map.empty
                    , _failure = Map.empty
                    , _recentEvents = []
+                   , _originalBinary = Nothing
+                   , _patchedBinary = Nothing
                    }

--- a/tools/pate/Interactive/State.hs
+++ b/tools/pate/Interactive/State.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Interactive.State (
+  SourcePair(..),
   EquivalenceTest(..),
   Failure(..),
   State,
@@ -10,16 +11,23 @@ module Interactive.State (
   failure,
   recentEvents,
   originalBinary,
-  patchedBinary
+  patchedBinary,
+  sources
   ) where
 
 import qualified Control.Lens as L
 import qualified Data.Map.Strict as Map
 import qualified Data.Time as TM
+import qualified Language.C as LC
 
 import qualified Pate.Binary as PB
 import qualified Pate.Event as PE
 import qualified Pate.Types as PT
+
+data SourcePair f = SourcePair { originalSource :: f
+                               , patchedSource :: f
+                               }
+                  deriving (Eq, Ord, Read, Show)
 
 data EquivalenceTest arch where
   EquivalenceTest :: PE.Blocks arch -> PE.Blocks arch -> TM.NominalDiffTime -> EquivalenceTest arch
@@ -39,15 +47,17 @@ data State arch =
         -- ^ The N most recent events (most recent first), to be shown in the console
         , _originalBinary :: Maybe (PB.LoadedELF arch, PT.ParsedFunctionMap arch)
         , _patchedBinary :: Maybe (PB.LoadedELF arch, PT.ParsedFunctionMap arch)
+        , _sources :: Maybe (SourcePair LC.CTranslUnit)
         }
 
 $(L.makeLenses 'State)
 
-emptyState :: State arch
-emptyState = State { _successful = Map.empty
-                   , _indeterminate = Map.empty
-                   , _failure = Map.empty
-                   , _recentEvents = []
-                   , _originalBinary = Nothing
-                   , _patchedBinary = Nothing
-                   }
+emptyState :: Maybe (SourcePair LC.CTranslUnit) -> State arch
+emptyState ms = State { _successful = Map.empty
+                      , _indeterminate = Map.empty
+                      , _failure = Map.empty
+                      , _recentEvents = []
+                      , _originalBinary = Nothing
+                      , _patchedBinary = Nothing
+                      , _sources = ms
+                      }

--- a/tools/pate/Main.hs
+++ b/tools/pate/Main.hs
@@ -146,6 +146,7 @@ layout = PP.layoutPretty PP.defaultLayoutOptions
 terminalFormatEvent :: PE.Event arch -> PP.SimpleDocStream PPRT.AnsiStyle
 terminalFormatEvent evt =
   case evt of
+    PE.LoadedBinaries {} -> layout "Loaded original and patched binaries"
     PE.CheckedEquivalence (PE.Blocks origAddr _) (PE.Blocks patchedAddr _) res duration ->
       let pfx = mconcat [ "Checking original block at "
                         , PP.viaShow origAddr

--- a/tools/pate/pate.css
+++ b/tools/pate/pate.css
@@ -9,3 +9,8 @@
 .sat-inequivalent {
     color: red;
 }
+
+.basic-block {
+    border-style: solid;
+    margin-bottom: 10px;
+}

--- a/tools/pate/pate.css
+++ b/tools/pate/pate.css
@@ -14,3 +14,7 @@
     border-style: solid;
     margin-bottom: 10px;
 }
+
+.source-listing {
+    padding: 10px;
+}


### PR DESCRIPTION
Extend the visualization further. The thrust is to provide more context for interpreting verification results. Hopefully, it will get as far as showing the C source corresponding to test cases (only for simple single-file examples). Right now, it shows function names alongside blocks, where doing so is possible.