### PR TITLE
Auto-detect the architecture of the input binaries

### DIFF
--- a/arch/Pate/PPC.hs
+++ b/arch/Pate/PPC.hs
@@ -5,7 +5,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Pate.PPC
-  ( PPC.PPC64 )
+  ( PPC.PPC64, PPC.PPC32 )
 where
 
 import           Data.Type.Equality
@@ -20,8 +20,32 @@ import           Data.Macaw.PPC.Symbolic ()
 instance PB.ArchConstraints PPC.PPC64 where
   binArchInfo = PPC.ppc64_linux_info
 
+instance PB.ArchConstraints PPC.PPC32 where
+  binArchInfo = PPC.ppc32_linux_info
 
+-- | Calling convention details, see:
+--
+-- https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/assembler/idalangref_reg_use_conv.html
 instance PM.ValidArch PPC.PPC64 where
+  funCallStable reg = case reg of
+    PPC.PPC_GP (PPC.GPR i) -> i == 2 || (14 <= i && i <= 31)
+    PPC.PPC_FR (PPC.VSReg i) -> 14 <= i && i <= 31
+    -- PPC.PPC_LNK -> True
+    _ -> False
+  funCallArg reg = case reg of
+    PPC.PPC_GP (PPC.GPR i) -> 3 <= i && i <= 10
+    PPC.PPC_FR (PPC.VSReg i) -> 1 <= i && i <= 13
+    _ -> False
+  funCallRet reg = case reg of
+    PPC.PPC_GP (PPC.GPR i) -> i == 3 || i == 4
+    PPC.PPC_FR (PPC.VSReg i) -> 1 <= i && i <= 4
+    _ -> False
+  funCallIP reg = case reg of
+    PPC.PPC_LNK -> Just Refl
+    _ -> Nothing
+
+-- | The 32 bit and 64 bit architectures have the same calling convention
+instance PM.ValidArch PPC.PPC32 where
   funCallStable reg = case reg of
     PPC.PPC_GP (PPC.GPR i) -> i == 2 || (14 <= i && i <= 31)
     PPC.PPC_FR (PPC.VSReg i) -> 14 <= i && i <= 31

--- a/pate.cabal
+++ b/pate.cabal
@@ -92,6 +92,7 @@ common shared-exec
   default-language: Haskell2010
   build-depends: base,
                  bytestring,
+                 binary,
                  elf-edit,
                  containers,
                  filepath,

--- a/src/Pate/Event.hs
+++ b/src/Pate/Event.hs
@@ -6,6 +6,7 @@ module Pate.Event (
   Event(..)
   ) where
 
+import qualified Data.ElfEdit as DEE
 import qualified Data.Macaw.Discovery as MD
 import qualified Data.Time as TM
 
@@ -25,5 +26,6 @@ data EquivalenceResult arch = Equivalent
 -- This can include traditional logging information, but also statistics about
 -- verification successes and failures that can be streamed to the user.
 data Event arch where
+  ElfLoaderWarnings :: [DEE.ElfParseError] -> Event arch
   CheckedEquivalence :: Blocks arch -> Blocks arch -> EquivalenceResult arch -> TM.NominalDiffTime -> Event arch
   LoadedBinaries :: (PB.LoadedELF arch, PT.ParsedFunctionMap arch) -> (PB.LoadedELF arch, PT.ParsedFunctionMap arch) -> Event arch

--- a/tools/pate/Interactive.hs
+++ b/tools/pate/Interactive.hs
@@ -64,6 +64,8 @@ consumeEvents chan r0 = do
         PE.LoadedBinaries (oelf, omap) (pelf, pmap) -> do
           IOR.atomicModifyIORef' (stateRef r0) $ \s -> (s & originalBinary .~ Just (oelf, omap)
                                                           & patchedBinary .~ Just (pelf, pmap), ())
+        PE.ElfLoaderWarnings {} ->
+          IOR.atomicModifyIORef' (stateRef r0) $ \s -> (s & recentEvents %~ addRecent recentEventCount evt, ())
         PE.CheckedEquivalence origBlock@(PE.Blocks addr _) patchedBlock res duration -> do
           let et = EquivalenceTest origBlock patchedBlock duration
           case res of
@@ -144,6 +146,8 @@ renderEvent :: (PB.ArchConstraints arch) => State arch -> TP.Element -> PE.Event
 renderEvent st detailDiv evt =
   case evt of
     PE.LoadedBinaries {} -> TP.string "Loaded original and patched binaries"
+    PE.ElfLoaderWarnings pes ->
+      TP.ul #+ (map (\w -> TP.li #+ [TP.string (show w)]) pes)
     PE.CheckedEquivalence ob@(PE.Blocks (PT.ConcreteAddress origAddr) _) pb@(PE.Blocks (PT.ConcreteAddress patchedAddr) _) res duration -> do
       blockLink <- TP.a # TP.set TP.text (show origAddr)
                         # TP.set TP.href ("#" ++ show origAddr)


### PR DESCRIPTION
It will throw an error if the architectures don't match or are unsupported.
This change adds support for 32 bit PowerPC.