### PR TITLE
Disable MacOS CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,14 +20,7 @@ jobs:
         arch: [ 'ppc' ]
         ghc: ['8.6.5', '8.8.3', '8.10.1']
         cabal: ['3.2.0.0']
-        os: [ubuntu-latest, macOS-latest, windows-latest]
-        exclude:
-          - os: macOS-latest
-            ghc: 8.6.5
-          - os: macOS-latest
-            ghc: 8.8.3
-          - os: windows-latest
-            arch: ppc
+        os: [ubuntu-latest]
 
     name: GHC ${{ matrix.ghc }} on ${{ matrix.os }} pate-${{ matrix.arch }}
 


### PR DESCRIPTION
They have been failing for spurious reasons (out of memory and tar errors)