### PR TITLE
Use verification hints to guide code discovery

### DIFF
--- a/pate.cabal
+++ b/pate.cabal
@@ -18,6 +18,7 @@ extra-source-files:  CHANGELOG.md
 
 common shared
   build-depends:       base >= 4.10 && < 5,
+                       async >= 2.2 && < 2.3,
                        bv-sized >= 1 && < 1.1,
                        bytestring,
                        containers >= 0.5 && < 0.7,
@@ -162,7 +163,7 @@ executable pate-exec
                        Interactive,
                        Interactive.State
   hs-source-dirs:      tools/pate tools arch
-  build-depends:       async >= 2.2 && < 2.3,
+  build-depends:       async,
                        prettyprinter,
                        prettyprinter-ansi-terminal >= 1.1 && < 1.2,
                        utf8-string >= 1 && < 2,

--- a/src/Pate/Discovery.hs
+++ b/src/Pate/Discovery.hs
@@ -33,6 +33,7 @@ import qualified Data.Parameterized.Map as MapF
 import           Data.Parameterized.Some ( Some(..) )
 import           Data.Proxy ( Proxy(..) )
 import qualified Data.Traversable as DT
+import           Data.Word ( Word64 )
 
 import qualified Data.Macaw.BinaryLoader as MBL
 import qualified Data.Macaw.CFG as MC
@@ -51,6 +52,7 @@ import qualified What4.SatResult as WR
 import qualified Pate.Binary as PB
 import qualified Pate.Event as PE
 import qualified Pate.Equivalence as PEq
+import qualified Pate.Hints as PH
 import qualified Pate.Memory.MemTrace as MT
 import           Pate.Monad
 import qualified Pate.SimState as PSS
@@ -311,18 +313,34 @@ concreteJumpTargets pb = case MD.pblockTermStmt pb of
 -------------------------------------------------------
 -- Driving macaw to generate the initial block map
 
+addFunctionEntryHints
+  :: (MM.MemWidth (MC.ArchAddrWidth arch))
+  => proxy arch
+  -> MM.Memory (MC.ArchAddrWidth arch)
+  -> (name, Word64)
+  -> ([Word64], [MC.ArchSegmentOff arch])
+  -> ([Word64], [MC.ArchSegmentOff arch])
+addFunctionEntryHints _ mem (_name, addrWord) (invalid, entries) =
+  case MM.resolveAbsoluteAddr mem (fromIntegral addrWord) of
+    Nothing -> (addrWord : invalid, entries)
+    Just segOff -> (invalid, segOff : entries)
+
 runDiscovery ::
+  forall arch .
   ValidArch arch =>
   PB.LoadedELF arch ->
-  CME.ExceptT (EquivalenceError arch) IO (MM.MemSegmentOff (MC.ArchAddrWidth arch), ParsedFunctionMap arch)
-runDiscovery elf = do
+  PH.VerificationHints ->
+  CME.ExceptT (EquivalenceError arch) IO ([Word64], MM.MemSegmentOff (MC.ArchAddrWidth arch), ParsedFunctionMap arch)
+runDiscovery elf hints = do
   let
     bin = PB.loadedBinary elf
     archInfo = PB.archInfo elf
   entries <- F.toList <$> MBL.entryPoints bin
+  let mem = MBL.memoryImage bin
+  let (invalidHints, hintedEntries) = F.foldr (addFunctionEntryHints (Proxy @arch) mem) ([], entries) (PH.functionEntries hints)
   pfm <- goDiscoveryState $
-    MD.cfgFromAddrs archInfo (MBL.memoryImage bin) Map.empty entries []
-  return (head entries, pfm)
+    MD.cfgFromAddrs archInfo mem Map.empty hintedEntries []
+  return (invalidHints, head entries, pfm)
   where
   goDiscoveryState ds = id
     . fmap (IM.unionsWith Map.union)

--- a/src/Pate/Event.hs
+++ b/src/Pate/Event.hs
@@ -10,10 +10,17 @@ module Pate.Event (
   ) where
 
 import qualified Data.ElfEdit as DEE
+import qualified Data.List.NonEmpty as DLN
+import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Discovery as MD
+import qualified Data.Text as T
 import qualified Data.Time as TM
+import           Data.Word ( Word64 )
 
 import qualified Pate.Binary as PB
+import qualified Pate.Hints.CSV as PHC
+import qualified Pate.Hints.DWARF as PHD
+import qualified Pate.Hints.JSON as PHJ
 import qualified Pate.Types as PT
 import qualified Pate.Proof as PP
 
@@ -58,3 +65,8 @@ data Event arch where
   ElfLoaderWarnings :: [DEE.ElfParseError] -> Event arch
   CheckedEquivalence :: BlocksPair arch -> EquivalenceResult arch -> TM.NominalDiffTime -> Event arch
   LoadedBinaries :: (PB.LoadedELF arch, PT.ParsedFunctionMap arch) -> (PB.LoadedELF arch, PT.ParsedFunctionMap arch) -> Event arch
+  FunctionEntryInvalidHints :: [(T.Text, Word64)] -> Event arch
+  FunctionsDiscoveredFromHints :: [MC.ArchSegmentOff arch] -> Event arch
+  HintErrorsCSV :: DLN.NonEmpty PHC.CSVParseError -> Event arch
+  HintErrorsJSON :: DLN.NonEmpty PHJ.JSONError -> Event arch
+  HintErrorsDWARF :: DLN.NonEmpty PHD.DWARFError -> Event arch

--- a/src/Pate/Hints/CSV.hs
+++ b/src/Pate/Hints/CSV.hs
@@ -1,5 +1,6 @@
 module Pate.Hints.CSV (
-  parseFunctionHints
+  parseFunctionHints,
+  CSVParseError(..)
   ) where
 
 import qualified Data.ByteString.Lazy as BSL

--- a/src/Pate/Monad.hs
+++ b/src/Pate/Monad.hs
@@ -76,7 +76,6 @@ import           Control.Monad.State
 
 
 import qualified Data.ElfEdit as E
-import qualified Data.Foldable as F
 import           Data.Map (Map)
 import           Data.Set (Set)
 import qualified Data.Set as S
@@ -89,13 +88,11 @@ import qualified Data.Macaw.BinaryLoader.PPC.TOC as TOC
 import           Data.Parameterized.Classes
 import qualified Data.Parameterized.Context as Ctx
 import qualified Data.Parameterized.List as PL
-import qualified Data.Parameterized.Map as MapF
 import qualified Data.Parameterized.Nonce as N
 import           Data.Parameterized.Some
 
 import qualified Lumberjack as LJ
 
-import qualified Lang.Crucible.Backend as CB
 import qualified Lang.Crucible.FunctionHandle as CFH
 import qualified Lang.Crucible.Simulator as CS
 import qualified Lang.Crucible.LLVM.MemModel as CLM
@@ -110,7 +107,6 @@ import qualified What4.Expr.Builder as W4B
 import qualified What4.Expr.GroundEval as W4G
 import qualified What4.Interface as W4
 import qualified What4.SatResult as W4R
-import qualified What4.SemiRing as SR
 import qualified What4.Solver.Adapter as WSA
 import qualified What4.Symbol as WS
 

--- a/src/Pate/Types.hs
+++ b/src/Pate/Types.hs
@@ -40,6 +40,7 @@ module Pate.Types
   , concreteFromAbsolute
   , ParsedBlockMap(..)
   , ParsedFunctionMap
+  , parsedFunctionEntries
   , markEntryPoint
   , type WhichBinary
   , KnownBinary
@@ -162,6 +163,9 @@ newtype ParsedBlockMap arch ids = ParsedBlockMap
 -- You should expect (and check) that exactly one key exists at the function entry point level.
 type ParsedFunctionMap arch = IntervalMap (ConcreteAddress arch) (Map (MM.ArchSegmentOff arch) (Some (ParsedBlockMap arch)))
 
+-- | Return the list of entry points in the parsed function map
+parsedFunctionEntries :: ParsedFunctionMap arch -> [MM.ArchSegmentOff arch]
+parsedFunctionEntries = concatMap M.keys . IM.elems
 
 markEntryPoint ::
   MM.ArchSegmentOff arch ->

--- a/src/Pate/Verification.hs
+++ b/src/Pate/Verification.hs
@@ -28,7 +28,8 @@ module Pate.Verification
 import           Prelude hiding ( fail )
 
 import           GHC.Stack ( HasCallStack )
-import           Control.Monad ( void )
+import qualified Control.Concurrent.Async as CCA
+import           Control.Monad ( void, unless )
 import qualified Control.Monad.IO.Unlift as IO
 import qualified Control.Monad.Reader as CMR
 import qualified Control.Monad.State as CMS
@@ -43,7 +44,7 @@ import qualified Data.BitVector.Sized as BVS
 import qualified Data.Foldable as F
 import qualified Data.Functor.Compose as DFC
 import qualified Data.List as DL
-import           Data.Maybe (catMaybes)
+import           Data.Maybe ( catMaybes, maybeToList )
 import qualified Data.Map as M
 import           Data.Proxy ( Proxy(..) )
 import           Data.Set (Set)
@@ -97,6 +98,7 @@ import qualified Pate.Discovery as PD
 import           Pate.Equivalence
 import qualified Pate.Event as PE
 import qualified Pate.ExprMappable as PEM
+import qualified Pate.Hints as PH
 import qualified Pate.MemCell as PMC
 import qualified Pate.Memory.MemTrace as MT
 import           Pate.Monad
@@ -112,26 +114,76 @@ import           What4.ExprHelpers
 standardTimeout :: Timeout
 standardTimeout = Minutes 5
 
+-- | We run discovery in parallel, since we need to run it two or three times
+--
+-- Currently, we run discovery twice on the original binary: once without
+-- hints and again if hints are available.
+--
+-- We report any errors in the hints:
+--
+-- * Hints that point to non-code data (bad)
+--
+-- * Hints not appearing in our discovery (good)
+--
+-- We use the hinted results (if any)
+runDiscovery
+  :: (ValidArch arch)
+  => LJ.LogAction IO (PE.Event arch)
+  -> Maybe PH.VerificationHints
+  -> PB.LoadedELF arch
+  -> PB.LoadedELF arch
+  -> CME.ExceptT (EquivalenceError arch) IO (MM.ArchSegmentOff arch, ParsedFunctionMap arch, MM.ArchSegmentOff arch, ParsedFunctionMap arch)
+runDiscovery logAction mhints elf elf' = do
+  let discoverAsync e h = liftIO (CCA.async (CME.runExceptT (PD.runDiscovery e h)))
+  origDiscovery <- discoverAsync elf mempty
+  mHintedDiscovery <- DT.traverse (discoverAsync elf) mhints
+  patchedDiscovery <- discoverAsync elf' mempty
+  (_, oMainUnhinted, oPfmUnhinted) <- CME.liftEither =<< liftIO (CCA.wait origDiscovery)
+  (_, pMain, pPfm) <- CME.liftEither =<< liftIO (CCA.wait patchedDiscovery)
+  (oMain, oPfm) <- case mHintedDiscovery of
+    Nothing -> return (oMainUnhinted, oPfmUnhinted)
+    Just hintedDiscovery -> do
+      (hintErrors, oMain, oPfm) <- CME.liftEither =<< liftIO (CCA.wait hintedDiscovery)
+      unless (null hintErrors) $ do
+        let invalidSet = S.fromList hintErrors
+        let invalidEntries = [ (name, addr)
+                             | hints <- maybeToList mhints
+                             , (name, addr) <- PH.functionEntries hints
+                             , S.member addr invalidSet
+                             ]
+        liftIO $ LJ.writeLog logAction (PE.FunctionEntryInvalidHints invalidEntries)
+
+      let unhintedDiscoveredAddresses = S.fromList (parsedFunctionEntries oPfmUnhinted)
+      let hintedDiscoveredAddresses = S.fromList (parsedFunctionEntries oPfm)
+      let newAddrs = hintedDiscoveredAddresses `S.difference` unhintedDiscoveredAddresses
+      unless (S.null newAddrs) $ do
+        liftIO $ LJ.writeLog logAction (PE.FunctionsDiscoveredFromHints (F.toList newAddrs))
+
+      return (oMain, oPfm)
+
+  liftIO $ LJ.writeLog logAction (PE.LoadedBinaries (elf, oPfm) (elf', pPfm))
+  return (oMain, oPfm, pMain, pPfm)
+
 -- | Verify equality of the given binaries.
 verifyPairs ::
   forall arch.
   ValidArch arch =>
   LJ.LogAction IO (PE.Event arch) ->
+  Maybe PH.VerificationHints ->
   PB.LoadedELF arch ->
   PB.LoadedELF arch ->
   BlockMapping arch ->
   VerificationConfig ->
   [PatchPair arch] ->
   CME.ExceptT (EquivalenceError arch) IO Bool
-verifyPairs logAction elf elf' blockMap vcfg pPairs = do
+verifyPairs logAction mhints elf elf' blockMap vcfg pPairs = do
   Some gen <- liftIO N.newIONonceGenerator
   vals <- case MS.genArchVals (Proxy @MT.MemTraceK) (Proxy @arch) of
     Nothing -> CME.throwError $ equivalenceError UnsupportedArchitecture
     Just vs -> pure vs
   ha <- liftIO CFH.newHandleAllocator
-  (oMain, oPfm)  <- PD.runDiscovery elf
-  (pMain, pPfm) <- PD.runDiscovery elf'
-  liftIO $ LJ.writeLog logAction (PE.LoadedBinaries (elf, oPfm) (elf', pPfm))
+
+  (oMain, oPfm, pMain, pPfm) <- runDiscovery logAction mhints elf elf'
 
   sym <- liftIO $ CB.newSimpleBackend W4B.FloatRealRepr gen
   let cfg = W4.getConfiguration sym

--- a/tests/TestBase.hs
+++ b/tests/TestBase.hs
@@ -101,6 +101,7 @@ doTest mwb sv proxy@PL.ValidArchProxy fp = do
       , PL.infoPath = infoPath
       , PL.origPath = fp <.> "original" <.> "exe"
       , PL.patchedPath = fp <.> "patched" <.> "exe"
+      , PL.hints = Nothing
       , PL.verificationCfg =
 
           PT.defaultVerificationCfg { PT.cfgComputeEquivalenceFrames = computeFrames }

--- a/tools/pate/Main.hs
+++ b/tools/pate/Main.hs
@@ -23,10 +23,14 @@ import qualified Control.Concurrent.Async as CCA
 import           Control.Monad ( join )
 import qualified Data.Binary.Get as DB
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Foldable as F
+import qualified Data.List.NonEmpty as DLN
+import           Data.Maybe ( isNothing, maybeToList )
 import qualified Data.Traversable as T
 import qualified Language.C as LC
 import qualified Lumberjack as LJ
+import           Numeric ( showHex )
 import qualified Options.Applicative as OA
 import qualified Prettyprinter as PP
 import qualified Prettyprinter.Render.Terminal as PPRT
@@ -34,17 +38,70 @@ import qualified System.Exit as SE
 import qualified System.IO as IO
 
 import qualified Data.ElfEdit as DEE
+import qualified Data.Macaw.CFG as MC
 import           Data.Parameterized.Some ( Some(..) )
 
 import qualified Pate.AArch32 as AArch32
 import qualified Pate.Event as PE
 import qualified Pate.PPC as PPC
+import qualified Pate.Hints as PH
+import qualified Pate.Hints.CSV as PHC
+import qualified Pate.Hints.DWARF as PHD
+import qualified Pate.Hints.JSON as PHJ
 import qualified Pate.Loader as PL
 import qualified Pate.Types as PT
 import qualified Pate.CounterExample as PCE
 
 import qualified Interactive as I
 import qualified Interactive.State as IS
+
+parseHints
+  :: LJ.LogAction IO (PE.Event arch)
+  -> CLIOptions
+  -> IO (Maybe PH.VerificationHints)
+parseHints logAction opts
+  | noHints = return Nothing
+  | otherwise = do
+      anvills <- T.forM (anvillHints opts) $ \anvillFile -> do
+        bytes <- BSL.readFile anvillFile
+        let (hints, errs) = PHJ.parseAnvillSpecHints bytes
+        case errs of
+          e1 : es -> LJ.writeLog logAction (PE.HintErrorsJSON (e1 DLN.:| es))
+          _ -> return ()
+        return hints
+
+      probs <- T.forM (maybeToList (probabilisticHints opts)) $ \probFile -> do
+        bytes <- BSL.readFile probFile
+        let (hints, errs) = PHJ.parseProbabilisticHints bytes
+        case errs of
+          e1 : es -> LJ.writeLog logAction (PE.HintErrorsJSON (e1 DLN.:| es))
+          _ -> return ()
+        return hints
+
+      csvs <- T.forM (maybeToList (csvFunctionHints opts)) $ \csvFile -> do
+        bytes <- BSL.readFile csvFile
+        let (hints, errs) = PHC.parseFunctionHints bytes
+        case errs of
+          e1 : es -> LJ.writeLog logAction (PE.HintErrorsCSV (e1 DLN.:| es))
+          _ -> return ()
+        return hints
+
+      let dwarfSource = if dwarfHints opts then [originalBinary opts] else []
+      dwarves <- T.forM dwarfSource $ \elfFile -> do
+        bytes <- BSL.readFile elfFile
+        let (hints, errs) = PHD.parseDWARFHints bytes
+        case errs of
+          e1 : es -> LJ.writeLog logAction (PE.HintErrorsDWARF (e1 DLN.:| es))
+          _ -> return ()
+        return hints
+
+      return (Just (mconcat (concat [anvills, probs, csvs, dwarves])))
+  where
+    noHints = and [ null (anvillHints opts)
+                  , isNothing (probabilisticHints opts)
+                  , isNothing (csvFunctionHints opts)
+                  , not (dwarfHints opts)
+                  ]
 
 main :: IO ()
 main = do
@@ -55,6 +112,7 @@ main = do
     Right (elfErrs, Some proxy) -> do
       chan <- CC.newChan
       (logger, mConsumer) <- startLogger proxy (logTarget opts) chan
+      mVerificationHints <- parseHints logger opts
       LJ.writeLog logger (PE.ElfLoaderWarnings elfErrs)
       let
         infoPath = case blockInfo opts of
@@ -74,6 +132,7 @@ main = do
             , PL.patchedPath = patchedBinary opts
             , PL.logger = logger
             , PL.verificationCfg = verificationCfg
+            , PL.hints = mVerificationHints
             }
       PL.runEquivConfig cfg >>= \case
         Left err -> SE.die (show err)
@@ -93,6 +152,10 @@ data CLIOptions = CLIOptions
   , noDiscoverFuns :: Bool
   , noProofs :: Bool
   , trySimpleFrames :: Bool
+  , anvillHints :: [FilePath]
+  , probabilisticHints :: Maybe FilePath
+  , csvFunctionHints :: Maybe FilePath
+  , dwarfHints :: Bool
   } deriving (Eq, Ord, Read, Show)
 
 data LogTarget = Interactive (Maybe (IS.SourcePair FilePath))
@@ -179,7 +242,10 @@ layout = PP.layoutPretty PP.defaultLayoutOptions
 layoutLn :: PP.Doc ann -> PP.SimpleDocStream ann
 layoutLn doc = layout (doc <> PP.line)
 
-terminalFormatEvent :: PE.Event arch -> PP.SimpleDocStream PPRT.AnsiStyle
+ppHex :: (Integral a, Show a) => a -> PP.Doc ann
+ppHex i = PP.pretty (showHex i "")
+
+terminalFormatEvent :: (MC.MemWidth (MC.ArchAddrWidth arch)) => PE.Event arch -> PP.SimpleDocStream PPRT.AnsiStyle
 terminalFormatEvent evt =
   case evt of
     PE.LoadedBinaries {} -> layoutLn "Loaded original and patched binaries"
@@ -209,6 +275,17 @@ terminalFormatEvent evt =
           in layoutLn (pfx <> " " <> PP.brackets (PP.annotate failStyle "✗"))
     PE.ErrorRaised err -> layout (PP.pretty $ PCE.ppEquivalenceError err)
     PE.ProvenGoal _ prf _ -> layout (PP.viaShow prf)
+    PE.HintErrorsCSV errs -> layout (PP.vsep (map PP.viaShow (F.toList errs)))
+    PE.HintErrorsJSON errs -> layout (PP.vsep (map PP.viaShow (F.toList errs)))
+    PE.HintErrorsDWARF errs -> layout (PP.vsep (map PP.viaShow (F.toList errs)))
+    PE.FunctionEntryInvalidHints errs ->
+      layout ("Invalid function entry hints:" <> PP.line
+               <> PP.vsep [ PP.pretty fn <> "@" <> ppHex addr
+                          | (fn, addr) <- errs
+                          ])
+    PE.FunctionsDiscoveredFromHints extraAddrs ->
+      layout ("Additional functions discovered based on hits: " <> PP.line
+             <> PP.vcat (map PP.viaShow extraAddrs))
     -- FIXME: handle other events
     _ -> layout ""
 
@@ -321,3 +398,18 @@ cliOptions = OA.info (OA.helper <*> parser)
       (  OA.long "try-simple-frames"
       <> OA.help "Attempt simple frame propagation first, falling back to heuristic analysis upon failure."
       ))
+    <*> OA.many (OA.strOption
+        ( OA.long "anvill-hints"
+        <> OA.help "Parse an Anvill specification for code discovery hints"
+        ))
+    <*> OA.optional (OA.strOption
+        ( OA.long "probabilistic-hints"
+        <> OA.help "Parse a JSON file containing probabilistic function name/address hints"
+        ))
+    <*> OA.optional (OA.strOption
+        ( OA.long "csv-function-hints"
+         <> OA.help "Parse a CSV file containing function name/address hints"
+        ))
+    <*> OA.switch ( OA.long "dwarf-hints"
+                  <> OA.help "Extract hints from the unpatched DWARF binary"
+                  )


### PR DESCRIPTION
This commit adds command line options to accept filenames for hint files in
various formats.  It parses the files (if any) to construct hints.  Hints are
threaded through to the code discovery phase, which now uses them to guide code
discovery and also to double check them (and emit warnings if an error is
detected).

Code discovery is now parallelized, since we may need to run it as many as three
times.