### PR TITLE
Remove some redundant constraints

### DIFF
--- a/src/Pate/CounterExample.hs
+++ b/src/Pate/CounterExample.hs
@@ -312,7 +312,6 @@ ppEquivalenceError err = "-\n\t" ++ show err ++ "\n" -- TODO: pretty-print the e
 
 ppInequivalenceResult ::
   MS.SymArchConstraints arch =>
-  ShowF (MM.ArchReg arch) =>
   InequivalenceResult arch -> String
 ppInequivalenceResult (InequivalentResults traceDiff exitDiffs regDiffs _retDiffs reason) =
   ppReason reason ++ "\n" ++ ppExitCaseDiff exitDiffs ++ "\n" ++ ppPreRegs regDiffs ++ ppMemTraceDiff traceDiff ++ ppDiffs regDiffs

--- a/src/Pate/Discovery.hs
+++ b/src/Pate/Discovery.hs
@@ -336,8 +336,7 @@ runDiscovery elf = do
     ]
 
 archSegmentOffToInterval ::
-  ValidArch arch =>
-  (CME.MonadError (EquivalenceError arch) m, MM.MemWidth (MC.ArchAddrWidth arch)) =>
+  (ValidArch arch, CME.MonadError (EquivalenceError arch) m) =>
   MC.ArchSegmentOff arch ->
   Int ->
   m (IM.Interval (ConcreteAddress arch))

--- a/src/Pate/Equivalence.hs
+++ b/src/Pate/Equivalence.hs
@@ -192,7 +192,6 @@ memPredFalse sym = MemPred MapF.empty (W4.truePred sym)
 footPrintsToPred ::
   forall sym arch.
   W4.IsSymExprBuilder sym =>
-  OrdF (W4.SymExpr sym) =>
   sym ->
   Set (MT.MemFootprint sym (MM.ArchAddrWidth arch)) ->
   W4.Pred sym ->
@@ -212,7 +211,6 @@ footPrintsToPred sym foots polarity = do
 addFootPrintsToPred ::
   forall sym arch.
   W4.IsSymExprBuilder sym =>
-  OrdF (W4.SymExpr sym) =>
   sym ->
   Set (MT.MemFootprint sym (MM.ArchAddrWidth arch)) ->
   MemPred sym arch ->
@@ -348,8 +346,6 @@ stateEquivalence sym stackRegion =
 getPrecondition ::
   forall sym arch.
   W4.IsSymExprBuilder sym =>
-  OrdF (W4.SymExpr sym) =>
-  OrdF (MM.ArchReg arch) =>
   MM.RegisterInfo (MM.ArchReg arch) =>
   sym ->
   -- | stack memory region
@@ -366,8 +362,6 @@ getPrecondition sym stackRegion bundle eqRel stPred = do
 impliesPrecondition ::
   forall sym arch.
   W4.IsSymExprBuilder sym =>
-  OrdF (W4.SymExpr sym) =>
-  OrdF (MM.ArchReg arch) =>
   MM.RegisterInfo (MM.ArchReg arch) =>
   sym ->
   -- | stack memory region
@@ -387,8 +381,6 @@ impliesPrecondition sym stackRegion inO inP eqRel stPredAsm stPredConcl = do
 -- structured equivalence relation (for reporting counterexamples)
 getPostcondition ::
   W4.IsSymExprBuilder sym =>
-  OrdF (W4.SymExpr sym) =>
-  OrdF (MM.ArchReg arch) =>
   MM.RegisterInfo (MM.ArchReg arch) =>
   sym ->
   SimBundle sym arch ->
@@ -430,8 +422,6 @@ weakenEquivRelation sym stPred eqRel =
 memPredPost ::
   forall sym arch.
   W4.IsSymExprBuilder sym =>
-  OrdF (W4.SymExpr sym) =>
-  OrdF (MM.ArchReg arch) =>
   MM.RegisterInfo (MM.ArchReg arch) =>
   sym ->
   SimOutput sym arch PT.Original ->
@@ -508,8 +498,6 @@ resolveCellEquiv sym stO stP eqRel cell cond = do
 memPredPre ::
   forall sym arch.
   W4.IsSymExprBuilder sym =>
-  OrdF (W4.SymExpr sym) =>
-  OrdF (MM.ArchReg arch) =>
   MM.RegisterInfo (MM.ArchReg arch) =>
   sym ->
   MemRegionEquality sym arch ->
@@ -593,8 +581,6 @@ memEqAtRegion sym stackRegion = MemRegionEquality $ \mem1 mem2 -> do
 regPredRel ::
   forall sym arch.
   W4.IsExprBuilder sym =>
-  OrdF (W4.SymExpr sym) =>
-  OrdF (MM.ArchReg arch) =>
   MM.RegisterInfo (MM.ArchReg arch) =>
   sym ->
   SimState sym arch PT.Original ->
@@ -612,8 +598,6 @@ regPredRel sym stO stP regEquiv regPred  = do
 
 statePredPre ::
   W4.IsSymExprBuilder sym =>
-  OrdF (W4.SymExpr sym) =>
-  OrdF (MM.ArchReg arch) =>
   MM.RegisterInfo (MM.ArchReg arch) =>
   sym ->
   -- | stack memory region
@@ -637,8 +621,6 @@ statePredPre sym stackRegion inO inP eqRel stPred  = do
 
 statePredPost ::
   W4.IsSymExprBuilder sym =>
-  OrdF (W4.SymExpr sym) =>
-  OrdF (MM.ArchReg arch) =>
   MM.RegisterInfo (MM.ArchReg arch) =>
   sym ->
   SimOutput sym arch PT.Original ->

--- a/src/Pate/Memory/MemTrace.hs
+++ b/src/Pate/Memory/MemTrace.hs
@@ -709,7 +709,6 @@ compatSub = RegionConstraint msg $ \sym reg1 reg2 -> do
     msg = "first pointer region must be zero, or both regions must be equal"
 
 ptrOp ::
-  IsSymInterface sym =>
   AddrWidthRepr w ->
   RegEntry sym (LLVMPointerType w) ->
   RegEntry sym (LLVMPointerType w) ->
@@ -721,7 +720,6 @@ ptrOp w (RegEntry _ (LLVMPointer region offset)) (RegEntry _ (LLVMPointer region
     f sym region offset region' offset'
         
 ptrPredOp ::
-  1 <= w =>
   IsSymInterface sym =>
   UndefinedPtrPredOp sym ->
   RegionConstraint sym ->
@@ -751,7 +749,6 @@ muxPtr sym p (LLVMPointer region offset) (LLVMPointer region' offset') = do
   return $ LLVMPointer reg'' off''
 
 ptrBinOp ::
-  1 <= w => 
   IsSymInterface sym =>
   UndefinedPtrBinOp sym ->
   RegionConstraint sym ->
@@ -877,7 +874,6 @@ arrayIdx sym ptr@(LLVMPointer reg off) off' = do
   return $ Empty :> reg :> bvIdx
 
 eqIdx ::
-  1 <= ptrW =>
   IsSymInterface sym =>
   sym ->
   Assignment (SymExpr sym) (EmptyCtx ::> BaseNatType ::> BaseBVType ptrW) ->
@@ -1040,7 +1036,6 @@ readMemArr sym mem ptr repr = go 0 repr
 writeMemArr :: forall sym ptrW w.
   1 <= ptrW =>
   IsExprBuilder sym =>
-  MemWidth ptrW =>
   sym ->
   MemTraceImpl sym ptrW ->
   LLVMPtr sym ptrW ->

--- a/src/Pate/SimState.hs
+++ b/src/Pate/SimState.hs
@@ -379,7 +379,6 @@ flatVars simVars =
 flatVarBinds ::
   forall sym arch bin.
   HasCallStack =>
-  W4.IsSymExprBuilder sym =>
   MM.RegisterInfo (MM.ArchReg arch) =>
   sym ->
   SimVars sym arch bin ->

--- a/src/Pate/Types.hs
+++ b/src/Pate/Types.hs
@@ -274,8 +274,7 @@ addressAddOffset :: (MM.MemWidth (MM.ArchAddrWidth arch))
 addressAddOffset (ConcreteAddress memAddr) memWord =
   ConcreteAddress (MM.incAddr (fromIntegral memWord) memAddr)
 
-concreteFromAbsolute :: (MM.MemWidth (MM.ArchAddrWidth arch))
-                     => MM.MemWord (MM.ArchAddrWidth arch)
+concreteFromAbsolute :: MM.MemWord (MM.ArchAddrWidth arch)
                      -> ConcreteAddress arch
 concreteFromAbsolute = ConcreteAddress . MM.absoluteAddr
 

--- a/src/Pate/Verification.hs
+++ b/src/Pate/Verification.hs
@@ -480,7 +480,6 @@ externalTransitions internalAddrs pb =
 -- simulation. Execute the given function in a context where the given 'SimBundle'
 -- is valid (i.e. its bound variables are marked free and its preconditions are assumed).
 withSimBundle ::
-  PEM.ExprMappable sym f =>
   PatchPair arch ->
   (SimBundle sym arch -> EquivM sym arch f) ->
   EquivM sym arch (SimSpec sym arch f)

--- a/src/What4/ExprHelpers.hs
+++ b/src/What4/ExprHelpers.hs
@@ -165,7 +165,6 @@ data VarBinding sym tp =
 
 mapExprPtr ::
   forall sym w.
-  W4.IsSymExprBuilder sym =>
   sym ->
   (forall tp. W4.SymExpr sym tp -> IO (W4.SymExpr sym tp)) ->
   CLM.LLVMPtr sym w ->


### PR DESCRIPTION
Remove some redundant constraints identified by `-Wredundant-constraints`. Not all are easy to remove (or a good idea), but trimming these seems reasonable.