### PR TITLE
Move the interactive UI components into the library

### DIFF
--- a/pate.cabal
+++ b/pate.cabal
@@ -42,6 +42,12 @@ common shared
                        panic >= 0.4 && < 0.5,
                        lumberjack >= 0.1 && < 1.1,
                        prettyprinter >= 1.7 && < 1.8,
+                       threepenny-gui >= 0.9 && < 0.10,
+                       filepath,
+                       temporary >= 1 && < 2,
+                       file-embed >= 0.0.12 && < 0.0.14,
+                       utf8-string >= 1 && < 2,
+                       language-c >= 0.9 && < 0.10,
                        parameterized-utils,
                        what4 >= 1 && < 2,
                        crucible,
@@ -94,7 +100,14 @@ library
                        What4.PathCondition,
                        Data.Parameterized.SetF,
                        Pate.SimState,
-                       Pate.Equivalence
+                       Pate.Equivalence,
+
+                       Pate.Interactive,
+                       Pate.Interactive.Render.BlockPairDetail,
+                       Pate.Interactive.Render.Console,
+                       Pate.Interactive.Render.Proof,
+                       Pate.Interactive.Render.SliceGraph,
+                       Pate.Interactive.State
 
 common shared-test
   ghc-options: -Wall -Wcompat
@@ -173,26 +186,16 @@ executable pate-exec
   import:              shared-exec, shared
   main-is:             Main.hs
   other-modules:       Pate.PPC,
-                       Pate.AArch32,
-                       Interactive,
-                       Interactive.Render.BlockPairDetail,
-                       Interactive.Render.Console,
-                       Interactive.Render.Proof,
-                       Interactive.Render.SliceGraph,
-                       Interactive.State
+                       Pate.AArch32
   hs-source-dirs:      tools/pate tools arch
   build-depends:       async,
                        aeson,
-                       temporary >= 1 && < 2,
                        prettyprinter,
                        prettyprinter-ansi-terminal >= 1.1 && < 1.2,
-                       utf8-string >= 1 && < 2,
-                       file-embed >= 0.0.12 && < 0.0.14,
                        time,
                        ansi-wl-pprint,
                        lumberjack >= 0.1 && < 1.1,
                        threepenny-gui >= 0.9 && < 0.10,
-                       language-c >= 0.9 && < 0.10,
                        parameterized-utils,
                        what4,
                        macaw-ppc,

--- a/src/Pate/Interactive.hs
+++ b/src/Pate/Interactive.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
-module Interactive (
+module Pate.Interactive (
   consumeEvents,
   startInterface,
   StateRef,
@@ -38,10 +38,10 @@ import qualified Pate.Metrics as PM
 import qualified Pate.Proof as PPr
 import qualified Pate.Types as PT
 
-import qualified Interactive.Render.BlockPairDetail as IRB
-import qualified Interactive.Render.Console as IRC
-import qualified Interactive.Render.Proof as IRP
-import           Interactive.State
+import qualified Pate.Interactive.Render.BlockPairDetail as IRB
+import qualified Pate.Interactive.Render.Console as IRC
+import qualified Pate.Interactive.Render.Proof as IRP
+import           Pate.Interactive.State
 
 -- | Embed the CSS we need into the Haskell to ensure that binaries can be relocatable
 cssContent :: BS.ByteString

--- a/src/Pate/Interactive/Render/BlockPairDetail.hs
+++ b/src/Pate/Interactive/Render/BlockPairDetail.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE RankNTypes #-}
-module Interactive.Render.BlockPairDetail (
+module Pate.Interactive.Render.BlockPairDetail (
   renderBlockPairDetail
   ) where
 
@@ -21,8 +21,8 @@ import qualified Pate.Event as PE
 import qualified Pate.Proof.Instances as PFI
 import qualified Pate.Types as PT
 
-import qualified Interactive.Render.SliceGraph as IRS
-import qualified Interactive.State as IS
+import qualified Pate.Interactive.Render.SliceGraph as IRS
+import qualified Pate.Interactive.State as IS
 
 renderCounterexample :: PE.EquivalenceResult arch -> [TP.UI TP.Element]
 renderCounterexample er =

--- a/src/Pate/Interactive/Render/Console.hs
+++ b/src/Pate/Interactive/Render/Console.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE GADTs #-}
-module Interactive.Render.Console (
+module Pate.Interactive.Render.Console (
   renderConsole
   ) where
 
@@ -17,8 +17,8 @@ import qualified Pate.Proof as PPr
 import qualified Pate.Proof.Instances as PFI
 import qualified Pate.Types as PT
 
-import qualified Interactive.Render.BlockPairDetail as IRB
-import qualified Interactive.State as IS
+import qualified Pate.Interactive.Render.BlockPairDetail as IRB
+import qualified Pate.Interactive.State as IS
 
 -- | Show the original block at the given address (as well as its corresponding patched block)
 --

--- a/src/Pate/Interactive/Render/Proof.hs
+++ b/src/Pate/Interactive/Render/Proof.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-module Interactive.Render.Proof (
+module Pate.Interactive.Render.Proof (
     renderProof
   , renderProofApp
   ) where
@@ -38,7 +38,7 @@ import qualified Pate.Proof as PPr
 import qualified Pate.Proof.Instances as PFI
 import qualified Pate.Types as PT
 
-import qualified Interactive.State as IS
+import qualified Pate.Interactive.State as IS
 
 pp :: PP.Doc ann -> T.Text
 pp = PPT.renderStrict . PP.layoutCompact

--- a/src/Pate/Interactive/Render/SliceGraph.hs
+++ b/src/Pate/Interactive/Render/SliceGraph.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-module Interactive.Render.SliceGraph (
+module Pate.Interactive.Render.SliceGraph (
   renderSliceGraph
   ) where
 

--- a/src/Pate/Interactive/State.hs
+++ b/src/Pate/Interactive/State.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
-module Interactive.State (
+module Pate.Interactive.State (
   SourcePair(..),
   EquivalenceTest(..),
   Failure(..),

--- a/tools/pate/Main.hs
+++ b/tools/pate/Main.hs
@@ -56,8 +56,8 @@ import qualified Pate.Solver as PS
 import qualified Pate.Timeout as PTi
 import qualified Pate.Types as PT
 
-import qualified Interactive as I
-import qualified Interactive.State as IS
+import qualified Pate.Interactive as I
+import qualified Pate.Interactive.State as IS
 
 parseHints
   :: LJ.LogAction IO (PE.Event arch)


### PR DESCRIPTION
This code could be productively reused in some other contexts. Moving it into
the library enables that with only the minor downside of adding some extra
dependencies to the library core.