### PR TITLE
Make address handling more robust

### DIFF
--- a/src/Pate/Address.hs
+++ b/src/Pate/Address.hs
@@ -2,9 +2,8 @@
 {-# LANGUAGE StandaloneDeriving #-}
 module Pate.Address (
     ConcreteAddress(..)
-  , absoluteAddress
+  , addressFromMemAddr
   , addressAddOffset
-  , concreteFromAbsolute
   ) where
 
 import qualified Prettyprinter as PP
@@ -19,11 +18,6 @@ deriving instance Show (ConcreteAddress arch)
 instance PP.Pretty (ConcreteAddress arch) where
   pretty (ConcreteAddress addr) = PP.pretty addr
 
-absoluteAddress :: (MM.MemWidth (MM.ArchAddrWidth arch)) => ConcreteAddress arch -> MM.MemWord (MM.ArchAddrWidth arch)
-absoluteAddress (ConcreteAddress memAddr) = absAddr
-  where
-    Just absAddr = MM.asAbsoluteAddr memAddr
-
 addressAddOffset :: (MM.MemWidth (MM.ArchAddrWidth arch))
                  => ConcreteAddress arch
                  -> MM.MemWord (MM.ArchAddrWidth arch)
@@ -31,6 +25,7 @@ addressAddOffset :: (MM.MemWidth (MM.ArchAddrWidth arch))
 addressAddOffset (ConcreteAddress memAddr) memWord =
   ConcreteAddress (MM.incAddr (fromIntegral memWord) memAddr)
 
-concreteFromAbsolute :: MM.MemWord (MM.ArchAddrWidth arch)
-                     -> ConcreteAddress arch
-concreteFromAbsolute = ConcreteAddress . MM.absoluteAddr
+addressFromMemAddr
+  :: MM.MemAddr (MM.ArchAddrWidth arch)
+  -> ConcreteAddress arch
+addressFromMemAddr = ConcreteAddress

--- a/src/Pate/Block.hs
+++ b/src/Pate/Block.hs
@@ -16,6 +16,7 @@ module Pate.Block (
 
 import qualified Data.Macaw.CFG as MM
 import qualified Data.Parameterized.Classes as PC
+import qualified Prettyprinter as PP
 
 import qualified Pate.Address as PA
 import qualified Pate.Binary as PB
@@ -56,10 +57,9 @@ getConcreteBlock ::
   MM.ArchSegmentOff arch ->
   BlockEntryKind arch ->
   PB.WhichBinaryRepr bin ->
-  Maybe (ConcreteBlock arch bin)
-getConcreteBlock off k bin = case MM.segoffAsAbsoluteAddr off of
-  Just addr -> Just $ ConcreteBlock (PA.ConcreteAddress (MM.absoluteAddr addr)) k bin
-  _ -> Nothing
+  ConcreteBlock arch bin
+getConcreteBlock off k bin =
+  ConcreteBlock (PA.ConcreteAddress (MM.segoffAddr off)) k bin
 
 blockMemAddr :: ConcreteBlock arch bin -> MM.MemAddr (MM.ArchAddrWidth arch)
 blockMemAddr (ConcreteBlock (PA.ConcreteAddress addr) _ _) = addr
@@ -90,4 +90,7 @@ instance MM.MemWidth (MM.ArchAddrWidth arch) => PC.ShowF (ConcreteBlock arch) wh
   showF blk = show blk
 
 ppBlock :: MM.MemWidth (MM.ArchAddrWidth arch) => ConcreteBlock arch bin -> String
-ppBlock b = show (PA.absoluteAddress (concreteAddress b))
+ppBlock b = show (concreteAddress b)
+
+instance (MM.MemWidth (MM.ArchAddrWidth arch)) => PP.Pretty (ConcreteBlock arch bin) where
+  pretty = PP.viaShow . concreteAddress

--- a/src/Pate/Equivalence/Error.hs
+++ b/src/Pate/Equivalence/Error.hs
@@ -44,10 +44,8 @@ data InnerEquivalenceError arch
   | InconclusiveSAT
   | NoUniqueFunctionOwner (IM.Interval (PA.ConcreteAddress arch)) [MM.ArchSegmentOff arch]
   | LookupNotAtFunctionStart (PA.ConcreteAddress arch) (PA.ConcreteAddress arch)
-  | StrangeBlockAddress (MM.ArchSegmentOff arch)
   -- starting address of the block, then a starting and ending address bracketing a range of undiscovered instructions
   | UndiscoveredBlockPart (PA.ConcreteAddress arch) (PA.ConcreteAddress arch) (PA.ConcreteAddress arch)
-  | NonConcreteParsedBlockAddress (MM.ArchSegmentOff arch)
   | BlockExceedsItsSegment (MM.ArchSegmentOff arch) (MM.ArchAddrWord arch)
   | BlockEndsMidInstruction
   | BlockStartsEarly (MM.ArchAddrWord arch) (MM.ArchAddrWord arch)


### PR DESCRIPTION
This should enable more robust handling of PIC binaries, which are sometimes
compiled as essentially shared libraries. Instead of assuming absolute
addresses, we now search for relevant memory regions.

This relies on some support in the macaw-loader package.