### PR TITLE
Fix a bug in loop detection

### DIFF
--- a/src/Pate/Verification/SymbolicExecution.hs
+++ b/src/Pate/Verification/SymbolicExecution.hs
@@ -81,7 +81,7 @@ backJumps internalAddrs pb =
      MD.ParsedBranch _ _ tgt tgt' -> [tgt, tgt']
      MD.ParsedLookupTable _jt _ _ tgts -> F.toList tgts
      _ -> []
-  , tgt < MD.pblockAddr pb
+  , tgt <= MD.pblockAddr pb
   , tgt `Set.member` internalAddrs
   ]
 

--- a/src/Pate/Verification/SymbolicExecution.hs
+++ b/src/Pate/Verification/SymbolicExecution.hs
@@ -23,7 +23,9 @@ import qualified Data.Parameterized.TraversableFC as TFC
 import           Data.Proxy ( Proxy(..) )
 import qualified Data.Set as Set
 import           Data.String ( fromString )
-import           GHC.Stack ( HasCallStack )
+import qualified Data.Text as T
+import           GHC.Stack ( HasCallStack, callStack )
+import qualified Prettyprinter as PP
 import qualified System.IO as IO
 import qualified What4.Interface as W4
 import qualified What4.ProgramLoc as W4L
@@ -37,8 +39,10 @@ import qualified Lang.Crucible.Simulator as CS
 import qualified Lang.Crucible.Simulator.GlobalState as CGS
 
 import qualified Pate.Binary as PBi
+import qualified Pate.Block as PB
 import qualified Pate.Discovery as PD
 import qualified Pate.Equivalence.Error as PEE
+import qualified Pate.Event as PE
 import qualified Pate.Memory.MemTrace as PMT
 import           Pate.Monad
 import qualified Pate.SimState as PS
@@ -249,15 +253,25 @@ ppAbortedResult (CS.AbortedBranch loc _ t f) =
 
 -- | Symbolically execute a chunk of code under the preconditions determined by
 -- the compositional analysis
+--
+-- Returns:
+--
+-- 1. The assumption required for the symbolic execution to be total
+-- 2. The captured post-state
 simulate ::
   forall sym arch bin.
-  PBi.KnownBinary bin =>
+  (HasCallStack, PBi.KnownBinary bin) =>
   PS.SimInput sym arch bin ->
   EquivM sym arch (W4.Pred sym, PS.SimOutput sym arch bin)
 simulate simInput = withBinary @bin $ do
   -- rBlock/rb for renovate-style block, mBlocks/mbs for macaw-style blocks
   CC.SomeCFG cfg <- do
     CC.Some (DFC.Compose pbs_) <- PD.lookupBlocks (PS.simInBlock simInput)
+
+    let traceAddr = PB.concreteAddress (PS.simInBlock simInput)
+    emitEvent (PE.ProofTraceEvent callStack traceAddr traceAddr (T.pack "CFG:"))
+    emitEvent (PE.ProofTraceEvent callStack traceAddr traceAddr (T.pack (unlines (fmap (show . PP.pretty) pbs_))))
+
     -- See Note [Loop Breaking]
     let pb:pbs = DL.sortOn MD.pblockAddr pbs_
         -- Multiple ParsedBlocks may have the same address, so the delete
@@ -268,6 +282,10 @@ simulate simInput = withBinary @bin $ do
     let killEdges =
           concatMap (backJumps internalAddrs) (pb : pbs) ++
           concatMap (externalTransitions internalAddrs) (pb:pbs)
+
+    emitEvent (PE.ProofTraceEvent callStack traceAddr traceAddr (T.pack ("Block index: " ++ show internalAddrs)))
+    emitEvent (PE.ProofTraceEvent callStack traceAddr traceAddr (T.pack ("Discarding edges: " ++ show killEdges)))
+
     fns <- archFuns
     ha <- CMR.asks (handles . envCtx)
     be <- CMR.asks envBlockEndVar

--- a/src/Pate/Verification/SymbolicExecution.hs
+++ b/src/Pate/Verification/SymbolicExecution.hs
@@ -271,7 +271,8 @@ simulate simInput = withBinary @bin $ do
     fns <- archFuns
     ha <- CMR.asks (handles . envCtx)
     be <- CMR.asks envBlockEndVar
-    liftIO $ MS.mkBlockSliceCFG fns ha (W4L.OtherPos . fromString . show) pb nonTerminal terminal killEdges (Just be)
+    let posFn = W4L.OtherPos . fromString . show
+    liftIO $ MS.mkBlockSliceCFG fns ha posFn pb nonTerminal terminal killEdges (Just be)
   let preRegs = PS.simInRegs simInput
   preRegsAsn <- regStateToAsn preRegs
   archRepr <- archStructRepr

--- a/tools/pate/Main.hs
+++ b/tools/pate/Main.hs
@@ -241,6 +241,8 @@ startLogger (PA.SomeValidArch {}) verb lt chan =
       logToHandle hdl
     Interactive port mSourceFiles mTraceFile -> do
       mTraceHandle <- T.traverse (\fp -> IO.openFile fp IO.WriteMode) mTraceFile
+      F.forM_ mTraceHandle $ \hdl -> do
+        IO.hSetBuffering hdl IO.NoBuffering
       -- This odd structure makes all of the threading explicit at this top
       -- level so that there is no thread creation hidden in the Interactive
       -- module


### PR DESCRIPTION
Fix a bug in the symbolic execution code that failed to detect some loops. The check was incomplete and allowed self-loops in some cases.