### PR TITLE
Abstract binary container format

### DIFF
--- a/pate.cabal
+++ b/pate.cabal
@@ -83,6 +83,7 @@ library
                        Pate.Verification.Validity,
                        Pate.Loader,
                        Pate.Loader.ELF,
+                       Pate.Loader.Wrapper,
                        Pate.Event,
                        Pate.Hints,
                        Pate.Hints.CSV,

--- a/src/Pate/Arch.hs
+++ b/src/Pate/Arch.hs
@@ -30,12 +30,11 @@ import qualified Pate.Verification.ExternalCall as PVE
 
 class
   ( MC.MemWidth (MC.ArchAddrWidth arch)
-  , MBL.BinaryLoader arch (E.ElfHeaderInfo (MC.ArchAddrWidth arch))
   , E.ElfWidthConstraints (MC.ArchAddrWidth arch)
   , MS.SymArchConstraints arch
   , 16 <= MC.RegAddrWidth (MC.ArchReg arch)
   ) => ArchConstraints arch where
-  binArchInfo :: MBL.LoadedBinary arch (E.ElfHeaderInfo (MC.ArchAddrWidth arch)) -> MI.ArchitectureInfo arch
+  binArchInfo :: MBL.LoadedBinary arch binFmt -> MI.ArchitectureInfo arch
 
 class TOC.HasTOC arch (E.ElfHeaderInfo (MC.ArchAddrWidth arch)) => HasTOCReg arch where
   toc_reg :: MC.ArchReg arch (MT.BVType (MC.ArchAddrWidth arch))
@@ -45,7 +44,6 @@ data HasTOCDict arch where
 
 class
   ( Typeable arch
-  , MBL.BinaryLoader arch (E.ElfHeaderInfo (MC.ArchAddrWidth arch))
   , MS.SymArchConstraints arch
   , MS.GenArchInfo PMT.MemTraceK arch
   , MC.ArchConstraints arch

--- a/src/Pate/Event.hs
+++ b/src/Pate/Event.hs
@@ -11,8 +11,6 @@ module Pate.Event (
 
 import qualified Data.ElfEdit as DEE
 import qualified Data.List.NonEmpty as DLN
-import qualified Data.Macaw.CFG as MC
-import qualified Data.Macaw.Discovery as MD
 import qualified Data.Text as T
 import qualified Data.Time as TM
 import           Data.Word ( Word64 )
@@ -20,19 +18,22 @@ import qualified GHC.Stack as GS
 import qualified What4.Expr as WE
 import qualified What4.Interface as WI
 
+import qualified Data.Macaw.CFG as MC
+import qualified Data.Macaw.Discovery as MD
+
 import qualified Pate.Address as PA
 import qualified Pate.Binary as PB
 import qualified Pate.Block as PB
+import qualified Pate.Equivalence.Error as PEE
+import qualified Pate.Equivalence.Statistics as PES
 import qualified Pate.Hints.CSV as PHC
 import qualified Pate.Hints.DWARF as PHD
 import qualified Pate.Hints.JSON as PHJ
+import qualified Pate.Loader.Wrapper as PLW
+import qualified Pate.PatchPair as PPa
 import qualified Pate.Proof as PF
 import qualified Pate.Proof.Instances as PFI
-import qualified Pate.PatchPair as PPa
-import qualified Pate.Equivalence.Error as PEE
-import qualified Pate.Equivalence.Statistics as PES
 import qualified Pate.Types as PT
-import qualified Pate.Loader.ELF as PLE
 
 -- | The macaw blocks relevant for a given code address
 data Blocks arch bin where
@@ -72,7 +73,9 @@ data Event arch where
   ComputedPrecondition :: BlocksPair arch -> TM.NominalDiffTime -> Event arch
   ElfLoaderWarnings :: [DEE.ElfParseError] -> Event arch
   CheckedEquivalence :: BlocksPair arch -> EquivalenceResult arch -> TM.NominalDiffTime -> Event arch
-  LoadedBinaries :: (PLE.LoadedELF arch, PT.ParsedFunctionMap arch) -> (PLE.LoadedELF arch, PT.ParsedFunctionMap arch) -> Event arch
+  LoadedBinaries :: (PLW.SomeLoadedBinary arch, PT.ParsedFunctionMap arch)
+                 -> (PLW.SomeLoadedBinary arch, PT.ParsedFunctionMap arch)
+                 -> Event arch
   -- | Function/block start hints that point to unmapped addresses
   FunctionEntryInvalidHints :: [(T.Text, Word64)] -> Event arch
   -- | A list of functions discovered from provided hints that macaw code

--- a/src/Pate/Interactive/State.hs
+++ b/src/Pate/Interactive/State.hs
@@ -40,10 +40,12 @@ import qualified Language.C as LC
 import qualified What4.Expr as WE
 import qualified What4.Interface as WI
 
+import qualified Data.Macaw.BinaryLoader as MBL
+
 import qualified Pate.Address as PA
 import qualified Pate.Event as PE
-import qualified Pate.Loader.ELF as PLE
 import qualified Pate.Metrics as PM
+import qualified Pate.Loader as PL
 import qualified Pate.Proof as PPr
 import qualified Pate.Proof.Instances as PFI
 import qualified Pate.Solver as PS
@@ -95,8 +97,8 @@ data State arch =
         , _failure :: Map.Map (PA.ConcreteAddress arch) (Failure arch)
         , _recentEvents :: [PE.Event arch]
         -- ^ The N most recent events (most recent first), to be shown in the console
-        , _originalBinary :: Maybe (PLE.LoadedELF arch, PT.ParsedFunctionMap arch)
-        , _patchedBinary :: Maybe (PLE.LoadedELF arch, PT.ParsedFunctionMap arch)
+        , _originalBinary :: Maybe (PL.SomeLoadedBinary arch), PT.ParsedFunctionMap arch)
+        , _patchedBinary :: Maybe (PL.SomeLoadedBinary arch), PT.ParsedFunctionMap arch)
         , _sources :: Maybe (SourcePair LC.CTranslUnit)
         , _proofTree :: Maybe (ProofTree arch)
         -- ^ All of the collected proof nodes received from the verifier

--- a/src/Pate/Loader.hs
+++ b/src/Pate/Loader.hs
@@ -10,6 +10,7 @@ module Pate.Loader
     runEquivVerification
   , runSelfEquivConfig
   , runEquivConfig
+  , SomeLoadedBinary(..)
   )
 where
 
@@ -32,6 +33,7 @@ import qualified Pate.Equivalence as PEq
 import qualified Pate.Event as PE
 import qualified Pate.Hints as PH
 import qualified Pate.Loader.ELF as PLE
+import           Pate.Loader.Wrapper ( SomeLoadedBinary(..) )
 import qualified Pate.PatchPair as PPa
 import qualified Pate.Types as PT
 import qualified Pate.Verification as PV

--- a/src/Pate/Loader/Wrapper.hs
+++ b/src/Pate/Loader/Wrapper.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE GADTs #-}
+module Pate.Loader.Wrapper ( SomeLoadedBinary(..) ) where
+
+import qualified Data.Macaw.BinaryLoader as MBL
+
+data SomeLoadedBinary arch where
+  SomeLoadedBinary :: (MBL.BinaryLoader arch binFmt) => MBL.LoadedBinary arch binFmt -> SomeLoadedBinary arch

--- a/src/Pate/Monad.hs
+++ b/src/Pate/Monad.hs
@@ -93,7 +93,6 @@ import           Control.Monad.Reader
 import           Control.Monad.Except
 import           Control.Monad.State
 
-import qualified Data.ElfEdit as E
 import           Data.Map (Map)
 import qualified Data.Map as M
 import           Data.Set (Set)
@@ -116,7 +115,6 @@ import qualified Lang.Crucible.FunctionHandle as CFH
 import qualified Lang.Crucible.Simulator as CS
 import qualified Lang.Crucible.LLVM.MemModel as CLM
 
-import qualified Data.Macaw.BinaryLoader as MBL
 import qualified Data.Macaw.CFG as MM
 import qualified Data.Macaw.Symbolic as MS
 import qualified Data.Macaw.Types as MM
@@ -132,14 +130,15 @@ import qualified What4.Symbol as WS
 import           What4.ExprHelpers
 
 import qualified Pate.Arch as PA
-import qualified Pate.Block as PB
 import qualified Pate.Binary as PBi
+import qualified Pate.Block as PB
 import qualified Pate.Config as PC
 import           Pate.Equivalence
 import qualified Pate.Equivalence.Error as PEE
 import qualified Pate.Equivalence.Statistics as PES
 import qualified Pate.Event as PE
 import qualified Pate.ExprMappable as PEM
+import qualified Pate.Loader.Wrapper as PLW
 import qualified Pate.Memory.MemTrace as MT
 import qualified Pate.Parallel as Par
 import qualified Pate.PatchPair as PPa
@@ -152,7 +151,7 @@ import qualified Pate.Timeout as PT
 import           Pate.Types
 
 data BinaryContext sym arch (bin :: PBi.WhichBinary) = BinaryContext
-  { binary :: MBL.LoadedBinary arch (E.ElfHeaderInfo (MM.ArchAddrWidth arch))
+  { binary :: PLW.SomeLoadedBinary arch
   , parsedFunctionMap :: ParsedFunctionMap arch
   , binEntry :: MM.ArchSegmentOff arch
   }

--- a/src/Pate/Register.hs
+++ b/src/Pate/Register.hs
@@ -51,6 +51,20 @@ registerCase repr r = case PC.testEquality r (MM.ip_reg @(MM.ArchReg arch)) of
   _ -> case PC.testEquality r (MM.sp_reg @(MM.ArchReg arch)) of
     Just PC.Refl -> RegSP
     _ -> PA.withTOCCases (Proxy @arch) nontoc $
+    -- FIXME: If we pass this the binary, we could test equality with a binrepr
+    -- here. That doesn't automatically recover the dictionary.
+    --
+    -- Perhaps instead we could store a GADT that lets us test the architecture
+    -- and stores the HasTOC constraint for PowerPC; we could just check here
+    -- for whether or not the arch is PPC (and recover the dict at the same
+    -- time).
+    --
+    -- That is fine for the verifier, which is allowed to have a closed set of
+    -- supported architectures.
+    --
+    -- Instead, we could wrap the whole notion of special treatment of a
+    -- register more abstractly. Either way, we need to be very flexible because
+    -- PowerPC32 doesn't use a TOC
       case PC.testEquality r (PA.toc_reg @arch) of
         Just PC.Refl -> RegTOC
         _ -> nontoc


### PR DESCRIPTION
This change doesn't compile. This is trying to make the core of the verifier
agnostic to the binary format (currently fixed as ELF). This was almost working,
except for the complex code that handles the PowerPC TOC. That logic will really
need to be refactored first.

The explicit reliance on the TOC means that we actually have to deal with the
`binFmt` type parameter somehow, which really complicates any change like
this. It is currently handled by fixing that parameter to ELF everywhere.