### PR TITLE
Modify the edge style in the UI

### DIFF
--- a/tools/pate/static/pate.js
+++ b/tools/pate/static/pate.js
@@ -105,7 +105,7 @@ function initializeGraphIn(nodeClickCallback, divId, nodeConfig, graphData) {
             { selector: 'edge',
               style: {
                   'width': 3,
-                  'curve-style': 'bezier',
+                  'curve-style': 'taxi',
                   'line-color': '#ccc',
                   'target-arrow-color': '#ccc',
                   'target-arrow-shape': 'triangle'


### PR DESCRIPTION
Instead of just straight lines (which tend to overlap nodes), use right-angle
edges (taxi edges in cytoscape terms).

Fixes #116