### PR TITLE
Tr/remove solver exceptions

### DIFF
--- a/src/Pate/Monad.hs
+++ b/src/Pate/Monad.hs
@@ -52,7 +52,6 @@ module Pate.Monad
   , memOpCondition
   -- sat helpers
   , checkSatisfiableWithModel
-  , isPredTrue
   , isPredSat
   , isPredTrue'
   , isPredTruePar'
@@ -612,20 +611,6 @@ isPredSat timeout p = case W4.asConstantPred p of
     W4R.Sat _ -> return True
     W4R.Unsat _ -> return False
     W4R.Unknown -> throwHere PEE.InconclusiveSAT
-
-isPredTrue ::
-  PT.Timeout ->
-  W4.Pred sym ->
-  EquivM sym arch Bool
-isPredTrue timeout p = case W4.asConstantPred p of
-  Just True -> return True
-  _ -> do
-    frame <- asks envCurrentFrame
-    case isAssumedPred frame p of
-      True -> return True
-      False -> do
-        notp <- withSymIO $ \sym -> W4.notPred sym p
-        not <$> isPredSat timeout notp
 
 -- | Same as 'isPredTrue' but does not throw an error if the result is inconclusive
 isPredTrue' ::

--- a/src/Pate/Verification.hs
+++ b/src/Pate/Verification.hs
@@ -379,7 +379,7 @@ checkEquivalence triple = startTimer $ withSym $ \sym -> do
     preImpliesGen <- liftIO $ impliesPrecondition sym stackRegion inO inP eqRel precond genPrecond
     -- prove that the generated precondition is implied by the given precondition
     goalTimeout <- CMR.asks (PC.cfgGoalTimeout . envConfig)
-    isPredTrue goalTimeout preImpliesGen >>= \case
+    isPredTrue' goalTimeout preImpliesGen >>= \case
       True -> return ()
       False -> throwHere PEE.ImpossibleEquivalence
 


### PR DESCRIPTION
Replace some uses of exceptions for control flow with explicit error handling around SMT solver failures. See #103 for details.