### PR TITLE
Relax the constraints we use for the AArch32 ABI

### DIFF
--- a/arch/Pate/AArch32.hs
+++ b/arch/Pate/AArch32.hs
@@ -82,7 +82,6 @@ handleExternalCall = PVE.ExternalDomain $ \sym -> do
                                , (Some (ARMReg.ARMGlobalBV (ASL.knownGlobalRef @"_R1")), WI.truePred sym)
                                , (Some (ARMReg.ARMGlobalBV (ASL.knownGlobalRef @"_R2")), WI.truePred sym)
                                , (Some (ARMReg.ARMGlobalBV (ASL.knownGlobalRef @"_R3")), WI.truePred sym)
-                               , (Some (ARMReg.ARMGlobalBV (ASL.knownGlobalRef @"_R11")), WI.truePred sym)
                                ]
   return $ PES.StatePred { PES.predRegs = regDomain
                          , PES.predStack = PEM.memPredTrue sym


### PR DESCRIPTION
The original implementation of the AArch32 ABI (used for missing function
bodies) included r11, which is not at all accurate. However, it was necessary to
get some important examples to run.

Now that #103 is fixed by #120, this is happily no longer necessary, so our ABI
spec can now be reasonable.