### PR TITLE
Fix a bug introduced by the recent TOC handling changes

### DIFF
--- a/arch/Pate/PPC.hs
+++ b/arch/Pate/PPC.hs
@@ -30,6 +30,7 @@ import qualified Data.Parameterized.NatRepr as PN
 import           Data.Parameterized.Some ( Some(..) )
 import           Data.Void ( Void, absurd )
 import           Data.Word ( Word8 )
+import           GHC.Stack ( HasCallStack )
 import           GHC.TypeLits
 import qualified What4.Interface as WI
 
@@ -83,7 +84,8 @@ ppc64AsDedicatedRegister reg =
 -- The returned value is the concrete address that would be in r2 at the
 -- start of the function
 getCurrentTOC
-  :: PMC.EquivalenceContext sym PPC.PPC64
+  :: (HasCallStack)
+  => PMC.EquivalenceContext sym PPC.PPC64
   -> PB.WhichBinaryRepr bin
   -> IO (W.W 64)
 getCurrentTOC ctx binRepr = do

--- a/src/Pate/Equivalence/Error.hs
+++ b/src/Pate/Equivalence/Error.hs
@@ -42,7 +42,7 @@ data InnerEquivalenceError arch
   | SymbolicExecutionFailed String -- TODO: do something better
   | InconclusiveSAT
   | NoUniqueFunctionOwner (IM.Interval (PA.ConcreteAddress arch)) [MM.ArchSegmentOff arch]
-  | LookupNotAtFunctionStart (PA.ConcreteAddress arch) (PA.ConcreteAddress arch)
+  | LookupNotAtFunctionStart CallStack (PA.ConcreteAddress arch) (PA.ConcreteAddress arch)
   -- starting address of the block, then a starting and ending address bracketing a range of undiscovered instructions
   | UndiscoveredBlockPart (PA.ConcreteAddress arch) (PA.ConcreteAddress arch) (PA.ConcreteAddress arch)
   | BlockExceedsItsSegment (MM.ArchSegmentOff arch) (MM.ArchAddrWord arch)


### PR DESCRIPTION
The bug was not specific to the TOC handling, but that commit generalized the
`lookupBlocks` function into `lookupBlocks'`, which was usable from more
contexts. Unfortunately, that change did not work as expected in cases where an
exception was thrown. The change turned some failures into an IO exception,
whereas before they were in the ExceptT monad (and caught).

Note that the case where this occurs may benefit from more explicit handling,
but the change in this commit restores the previous behavior (and removes the IO
exception from `lookupBlocks'`.