### PR TITLE
Plumb function argument names through the verifier

### DIFF
--- a/src/Pate/Arch.hs
+++ b/src/Pate/Arch.hs
@@ -18,6 +18,7 @@ module Pate.Arch (
   ) where
 
 import qualified Data.Kind as DK
+import qualified Data.Text as T
 import           Data.Typeable ( Typeable )
 import           GHC.TypeLits ( type (<=) )
 
@@ -107,6 +108,14 @@ class
   -- | Determine how a register should be displayed to a user in reports and an
   -- interactive context
   displayRegister :: forall tp . MC.ArchReg arch tp -> RegisterDisplay String
+  -- | From a name of formal argument parameters, determine the name of the
+  -- parameter in the given register (if any)
+  --
+  -- FIXME: To be correct, this really needs to account for the types of
+  -- arguments (e.g., large arguments are on the stack, while floating point
+  -- arguments are in FP registers). Longer term, this should use the abide
+  -- library
+  argumentNameFrom :: forall tp . [T.Text] -> MC.ArchReg arch tp -> Maybe T.Text
 
 -- | A witness to the validity of an architecture, along with any
 -- architecture-specific data required for the verifier

--- a/src/Pate/Hints/CSV.hs
+++ b/src/Pate/Hints/CSV.hs
@@ -29,13 +29,21 @@ parseAddress = MP.parseMaybe parseCodeHex
       _ <- MPC.string (T.pack "code:")
       MPCL.hexadecimal
 
-parseFunctionEntry :: ([(T.Text, Word64)], [CSVParseError]) -> [T.Text] -> ([(T.Text, Word64)], [CSVParseError])
+parseFunctionEntry
+  :: ([(T.Text, PH.FunctionDescriptor)], [CSVParseError])
+  -> [T.Text]
+  -> ([(T.Text, PH.FunctionDescriptor)], [CSVParseError])
 parseFunctionEntry (items, errs) row =
   case row of
     [name, addr] ->
       case parseAddress addr of
         Nothing -> (items, AddressParseError addr : errs)
-        Just a -> ((name, a) : items, errs)
+        Just a ->
+          let fd = PH.FunctionDescriptor { PH.functionSymbol = name
+                                         , PH.functionAddress = a
+                                         , PH.functionArguments = []
+                                         }
+          in ((name, fd) : items, errs)
     _ -> (items, UnexpectedRowShape row : errs)
 
 -- | Parse a CSV file that provides a mapping from function names to addresses

--- a/src/Pate/Monad/Context.hs
+++ b/src/Pate/Monad/Context.hs
@@ -43,6 +43,9 @@ data BinaryContext arch (bin :: PBi.WhichBinary) = BinaryContext
   , parsedFunctionMap :: ParsedFunctionMap arch
   , binEntry :: MM.ArchSegmentOff arch
   , hints :: PH.VerificationHints
+  , functionHintIndex :: Map.Map (PA.ConcreteAddress arch) PH.FunctionDescriptor
+  -- ^ An index of the binary hints by function entry point address, used in the
+  -- construction of function frames to name parameters
   , binAbortFn :: Maybe (MM.ArchSegmentOff arch)
   -- ^ address of special-purposes "abort" function that represents an abnormal
   -- program exit

--- a/src/Pate/Proof/Operations.hs
+++ b/src/Pate/Proof/Operations.hs
@@ -282,8 +282,8 @@ statePredToPostDomain stPredSpec = proofNonceExpr $ do
   PF.appDomain <$> statePredToDomain states stPred
 
 
-emptyDomain :: EquivM sym arch (PFI.ProofSymNonceExpr sym arch PF.ProofDomainType)
-emptyDomain = proofNonceExpr $ withSym $ \sym -> fmap PS.specBody $ withFreshVars $ \stO stP -> do
+emptyDomain :: PPa.BlockPair arch -> EquivM sym arch (PFI.ProofSymNonceExpr sym arch PF.ProofDomainType)
+emptyDomain blocks = proofNonceExpr $ withSym $ \sym -> fmap PS.specBody $ withFreshVars blocks $ \stO stP -> do
   dom <- PF.appDomain <$> statePredToDomain (PPa.PatchPair stO stP) (PES.statePredFalse sym)
   return $ (W4.truePred sym, dom)
 

--- a/tests/hints/01.anvill.json.expected
+++ b/tests/hints/01.anvill.json.expected
@@ -1,7 +1,7 @@
 VerificationHints { blockMappings = []
-                  , functionEntries = [ ("printf", 4195440)
-                                      , ("main", 4195712)
-                                      , ("puts", 4195424)
+                  , functionEntries = [ ("printf", FunctionDescriptor { functionSymbol = "printf", functionAddress = 4195440, functionArguments = [] })
+                                      , ("main", FunctionDescriptor { functionSymbol = "main", functionAddress = 4195712, functionArguments = [] })
+                                      , ("puts", FunctionDescriptor { functionSymbol = "puts", functionAddress = 4195424, functionArguments = [] })
                                       ]
                   , dataSymbols = [ ("errno", SymbolExtent { symbolLocation = 400, symbolSize = 4} )
                                   ]

--- a/tests/hints/01.elf.expected
+++ b/tests/hints/01.elf.expected
@@ -1,6 +1,6 @@
 VerificationHints { blockMappings = []
-                  , functionEntries = [ ("f1", 0x1000)
-                                      , ("main", 0x1017)
+                  , functionEntries = [ ("f1", FunctionDescriptor { functionSymbol = "f1", functionAddress = 0x1000, functionArguments = ["i"] })
+                                      , ("main", FunctionDescriptor { functionSymbol = "main", functionAddress = 0x1017, functionArguments = [] })
                                       ]
                   , dataSymbols = [ ("g1", SymbolExtent { symbolLocation = 0x4000, symbolSize = 4} )
                                   , ("g2", SymbolExtent { symbolLocation = 0x4008, symbolSize = 8} )

--- a/tests/hints/01.functions.csv.expected
+++ b/tests/hints/01.functions.csv.expected
@@ -1,8 +1,8 @@
 VerificationHints { blockMappings = []
-                  , functionEntries = [ ("thunk_FUN_code_00005d", 0x0)
-                                      , ("FUN_code_00005d", 0x5d)
-                                      , ("FUN_code_0000d6", 0xd6)
-                                      , ("__do_clear_bss", 0xdc)
+                  , functionEntries = [ ("thunk_FUN_code_00005d", FunctionDescriptor { functionSymbol = "thunk_FUN_code_00005d", functionAddress = 0x0, functionArguments = [] })
+                                      , ("FUN_code_00005d", FunctionDescriptor { functionSymbol = "FUN_code_00005d", functionAddress = 0x5d, functionArguments = [] })
+                                      , ("FUN_code_0000d6", FunctionDescriptor { functionSymbol = "FUN_code_0000d6", functionAddress = 0xd6, functionArguments = [] })
+                                      , ("__do_clear_bss", FunctionDescriptor { functionSymbol = "__do_clear_bss", functionAddress = 0xdc, functionArguments = [] })
                                       ]
                   , dataSymbols = []
                   }

--- a/tests/hints/01.prob.json.expected
+++ b/tests/hints/01.prob.json.expected
@@ -1,6 +1,6 @@
 VerificationHints { blockMappings = []
-                  , functionEntries = [ ("__do_global_dtors_aux", 0x080000c0)
-                                      , ("frame_dummy", 0x080000e8)
+                  , functionEntries = [ ("__do_global_dtors_aux", FunctionDescriptor { functionSymbol = "__do_global_dtors_aux", functionAddress = 0x080000c0, functionArguments = [] })
+                                      , ("frame_dummy", FunctionDescriptor { functionSymbol = "frame_dummy", functionAddress = 0x080000e8, functionArguments = []})
                                       ]
                   , dataSymbols = []
                   }

--- a/tests/hints/02.prob.json.expected
+++ b/tests/hints/02.prob.json.expected
@@ -1,6 +1,6 @@
 VerificationHints { blockMappings = []
-                  , functionEntries = [ ("UART_RxISR_16BIT", 0x080000c0)
-                                      , ("frame_dummy", 0x080000e8)
+                  , functionEntries = [ ("UART_RxISR_16BIT", FunctionDescriptor { functionSymbol = "UART_RxISR_16BIT", functionAddress = 0x080000c0, functionArguments = [] })
+                                      , ("frame_dummy", FunctionDescriptor { functionSymbol = "frame_dummy", functionAddress = 0x080000e8, functionArguments = [] })
                                       ]
                   , dataSymbols = []
                   }


### PR DESCRIPTION
These names are now used to allocate fresh symbolic values at the start of
slices (as long as the slice contains a function entry point). These should be
visible in generated diagnostics and differential summaries (but that needs to
be tested).