### PR TITLE
Pull operations on `ParsedBlockMap` and `ParsedFunctionMap` into

### DIFF
--- a/src/Pate/Discovery.hs
+++ b/src/Pate/Discovery.hs
@@ -30,7 +30,6 @@ import qualified Control.Monad.Reader as CMR
 import qualified Data.BitVector.Sized as BVS
 import qualified Data.Foldable as F
 import qualified Data.Functor.Compose as DFC
-import qualified Data.IntervalMap.Strict as IM
 import qualified Data.Map.Strict as Map
 import           Data.Maybe ( catMaybes )
 import qualified Data.Parameterized.Classes as PC
@@ -245,25 +244,26 @@ getSubBlocks ::
   PB.KnownBinary bin =>
   PB.ConcreteBlock arch bin ->
   EquivM sym arch [BlockTarget arch bin]
-getSubBlocks b = withBinary @bin $ do
-  pfm <- PMC.parsedFunctionMap <$> getBinCtx @bin
-  case Map.assocs $ Map.unions $ fmap snd $ IM.lookupLE i pfm of
-    [(_, Some (PMC.ParsedBlockMap pbm))] -> do
-      let pbs = concat $ IM.elems $ IM.intersecting pbm i
-      concat <$> mapM (concreteValidJumpTargets pbs) pbs
-    blks -> throwHere $ PEE.NoUniqueFunctionOwner i (fst <$> blks)
-  where
-  start@(PA.ConcreteAddress saddr) = PB.concreteAddress b
-  end = PA.ConcreteAddress (MM.MemAddr (MM.addrBase saddr) maxBound)
-  i = IM.OpenInterval start end
+getSubBlocks b = withBinary @bin $
+  do let addr = PB.concreteAddress b
+     pfm <- PMC.parsedFunctionMap <$> getBinCtx @bin
+     tgts <- case PMC.parsedFunctionContaining addr pfm of
+       Right (_, Some pbm) -> do
+         let pbs = PMC.parsedBlocksContaining addr pbm
+         concat <$> mapM (concreteValidJumpTargets pbs) pbs
+       Left allAddrs -> throwHere $ PEE.NoUniqueFunctionOwner addr allAddrs
+     mapM_ validateBlockTarget tgts
+     return tgts
+
 
 concreteValidJumpTargets ::
-  forall bin sym arch ids.
+  forall bin arch ids m.
+  Monad m =>
   PB.KnownBinary bin =>
   PA.ValidArch arch =>
   [MD.ParsedBlock arch ids] ->
   MD.ParsedBlock arch ids ->
-  EquivM sym arch [BlockTarget arch bin]
+  m [BlockTarget arch bin]
 concreteValidJumpTargets allPbs pb = do
   targets <- concreteJumpTargets pb
   let thisAddr = segOffToAddr (MD.pblockAddr pb)
@@ -275,7 +275,6 @@ concreteValidJumpTargets allPbs pb = do
 
     isTargetValid btgt = isTargetArch btgt || isTargetExternal btgt || isTargetBackJump btgt
   let validTargets = filter isTargetValid targets
-  mapM_ validateBlockTarget validTargets
   return validTargets
 
 validateBlockTarget ::
@@ -290,13 +289,6 @@ validateBlockTarget tgt = do
         Left err -> throwHere $ PEE.InvalidCallTarget (PB.concreteAddress blk) err
         Right _ -> return ()
     _ -> return ()
-
-mkConcreteBlock ::
-  PB.KnownBinary bin =>
-  PB.BlockEntryKind arch ->
-  MC.ArchSegmentOff arch ->
-  EquivM sym arch (PB.ConcreteBlock arch bin)
-mkConcreteBlock k a = return (PB.getConcreteBlock a k WI.knownRepr)
 
 mkConcreteBlock' ::
   PB.KnownBinary bin =>
@@ -327,11 +319,12 @@ concreteValueAddress = \case
   _ -> []
 
 concreteJumpTargets ::
-  forall bin sym arch ids.
+  forall bin arch ids m.
+  Monad m =>
   PB.KnownBinary bin =>
   PA.ValidArch arch =>
   MD.ParsedBlock arch ids ->
-  EquivM sym arch [BlockTarget arch bin]
+  m [BlockTarget arch bin]
 concreteJumpTargets pb = case MD.pblockTermStmt pb of
   MD.ParsedCall st ret -> go (concreteNextIPs st) ret
   MD.PLTStub st _ _ -> case MapF.lookup (MC.ip_reg @(MC.ArchReg arch)) st of
@@ -354,10 +347,20 @@ concreteJumpTargets pb = case MD.pblockTermStmt pb of
     go ::
       [PA.ConcreteAddress arch] ->
       Maybe (MC.ArchSegmentOff arch) ->
-      EquivM sym arch [BlockTarget arch bin]
+      m [BlockTarget arch bin]
     go next_ips ret = do
       ret_blk <- mapM (mkConcreteBlock PB.BlockEntryPostFunction) ret
       return $ [ BlockTarget (mkConcreteBlock' PB.BlockEntryInitFunction next) ret_blk | next <- next_ips ]
+
+mkConcreteBlock ::
+  forall bin arch m .
+  Applicative m =>
+  PA.ValidArch arch =>
+  PB.KnownBinary bin =>
+  PB.BlockEntryKind arch ->
+  MC.ArchSegmentOff arch ->
+  m (PB.ConcreteBlock arch bin)
+mkConcreteBlock k a = pure (PB.getConcreteBlock a k WI.knownRepr)
 
 -------------------------------------------------------
 -- Driving macaw to generate the initial block map
@@ -375,12 +378,6 @@ addFunctionEntryHints _ mem (_name, fd) (invalid, entries) =
     Just segOff -> (invalid, segOff : entries)
   where
     addrWord = PH.functionAddress fd
-
-markEntryPoint ::
-  MC.ArchSegmentOff arch ->
-  PMC.ParsedBlockMap arch ids ->
-  PMC.ParsedFunctionMap arch
-markEntryPoint segOff blocks = Map.singleton segOff (Some blocks) <$ PMC.getParsedBlockMap blocks
 
 -- | Special-purpose function name that is treated as abnormal program exit
 abortFnName :: T.Text
@@ -400,7 +397,6 @@ runDiscovery mCFGDir repr elf hints = do
   entries <- F.toList <$> MBL.entryPoints bin
   let (invalidHints, hintedEntries) = F.foldr (addFunctionEntryHints (Proxy @arch) mem) ([], entries) (PH.functionEntries hints)
   let ds = MD.cfgFromAddrs archInfo mem Map.empty hintedEntries []
-  pfm <- goDiscoveryState ds
 
   -- If the user wants to persist macaw CFGs, do so here
   --
@@ -413,42 +409,23 @@ runDiscovery mCFGDir repr elf hints = do
       IO.withFile fname IO.WriteMode $ \hdl -> do
         PPT.hPutDoc hdl (PP.pretty dfi)
 
+  let pfm = PMC.buildParsedFunctionMap ds
   let abortFnAddr = do
         abortFnWord <- PH.functionAddress <$> lookup abortFnName (PH.functionEntries hints)
         MM.resolveAbsoluteAddr mem (fromIntegral abortFnWord)
   let idx = F.foldl' addFunctionEntryHint Map.empty (PH.functionEntries hints)
   return $ (invalidHints, PMC.BinaryContext bin pfm (head entries) hints idx abortFnAddr)
   where
-  goDiscoveryState ds = id
-    . fmap (IM.unionsWith Map.union)
-    . mapM goSomeDiscoveryFunInfo
-    . Map.assocs
-    $ ds ^. MD.funInfo
-  goSomeDiscoveryFunInfo (entrySegOff, Some dfi) = markEntryPoint entrySegOff <$> goDiscoveryFunInfo dfi
-  goDiscoveryFunInfo dfi = fmap (PMC.ParsedBlockMap . IM.fromListWith (++)) . sequence $
-    [ (\addrs -> (addrs, [pb])) <$> archSegmentOffToInterval blockSegOff (MD.blockSize pb)
-    | (blockSegOff, pb) <- Map.assocs (dfi ^. MD.parsedBlocks)
-    ]
+    bin = PLE.loadedBinary elf
+    mem = MBL.memoryImage bin
 
-  bin = PLE.loadedBinary elf
-  mem = MBL.memoryImage bin
-
-  addFunctionEntryHint m (_, fd) =
-    let addrWord = PH.functionAddress fd
-    in case MBLE.resolveAbsoluteAddress mem (fromIntegral addrWord) of
-         Nothing -> m
-         Just segoff ->
-           let addr = PA.addressFromMemAddr (MM.segoffAddr segoff)
-           in Map.insert addr fd m
-
-archSegmentOffToInterval ::
-  (PA.ValidArch arch, CME.MonadError (PEE.EquivalenceError arch) m) =>
-  MC.ArchSegmentOff arch ->
-  Int ->
-  m (IM.Interval (PA.ConcreteAddress arch))
-archSegmentOffToInterval segOff size =
-  let start = PA.addressFromMemAddr (MM.segoffAddr segOff)
-  in pure (IM.IntervalCO start (start `PA.addressAddOffset` fromIntegral size))
+    addFunctionEntryHint m (_, fd) =
+      let addrWord = PH.functionAddress fd
+      in case MBLE.resolveAbsoluteAddress mem (fromIntegral addrWord) of
+           Nothing -> m
+           Just segoff ->
+             let addr = PA.addressFromMemAddr (MM.segoffAddr segoff)
+             in Map.insert addr fd m
 
 getBlocks'
   :: (CMC.MonadThrow m, MS.SymArchConstraints arch, Typeable arch, HasCallStack)
@@ -490,23 +467,18 @@ lookupBlocks'
   -> PB.ConcreteBlock arch bin
   -> Either (PEE.InnerEquivalenceError arch) (Some (DFC.Compose [] (MD.ParsedBlock arch)))
 lookupBlocks' binCtx b = do
-  let pfm = PMC.parsedFunctionMap binCtx
-  let fns = Map.assocs $ Map.unions $ fmap snd $ IM.lookupLE i pfm
-  let fns' = fmap (\(segOff, pbm) -> (segOffToAddr segOff, pbm)) fns
-  case reverse $ filter (\(addr', _) -> addr' <= start) fns' of
-    ((funAddr, Some (PMC.ParsedBlockMap pbm)):_) -> do
+  case PMC.parsedFunctionContaining addr (PMC.parsedFunctionMap binCtx) of
+    Right (funAddr, Some pbm) ->
       case PB.concreteBlockEntry b of
         PB.BlockEntryInitFunction
-          | funAddr /= start -> Left (PEE.LookupNotAtFunctionStart callStack funAddr start)
+          | funAddr /= addr -> Left (PEE.LookupNotAtFunctionStart callStack funAddr addr)
         _ -> do
-          let result = concat $ IM.elems $ IM.intersecting pbm i
+          let result = PMC.parsedBlocksContaining addr pbm
           return $ Some (DFC.Compose result)
-    _ -> Left (PEE.NoUniqueFunctionOwner i (fst <$> fns))
-  where
-    start@(PA.ConcreteAddress addr) = PB.concreteAddress b
-    end = PA.ConcreteAddress (MM.MemAddr (MM.addrBase addr) maxBound)
-    i = IM.OpenInterval start end
+    Left addrs -> Left (PEE.NoUniqueFunctionOwner addr addrs)
 
+  where
+    addr = PB.concreteAddress b
 
 lookupBlocks ::
   forall sym arch bin.

--- a/src/Pate/Equivalence/Error.hs
+++ b/src/Pate/Equivalence/Error.hs
@@ -11,7 +11,6 @@ module Pate.Equivalence.Error (
   ) where
 
 import qualified Control.Exception as X
-import qualified Data.IntervalMap as IM
 import           Data.Maybe ( catMaybes )
 import           Data.Parameterized.Some ( Some(..) )
 import           Data.Typeable ( Typeable )
@@ -41,7 +40,7 @@ data InnerEquivalenceError arch
   | UnsupportedRegisterType (Some CT.TypeRepr)
   | SymbolicExecutionFailed String -- TODO: do something better
   | InconclusiveSAT
-  | NoUniqueFunctionOwner (IM.Interval (PA.ConcreteAddress arch)) [MM.ArchSegmentOff arch]
+  | NoUniqueFunctionOwner (PA.ConcreteAddress arch) [MM.ArchSegmentOff arch]
   | LookupNotAtFunctionStart CallStack (PA.ConcreteAddress arch) (PA.ConcreteAddress arch)
   -- starting address of the block, then a starting and ending address bracketing a range of undiscovered instructions
   | UndiscoveredBlockPart (PA.ConcreteAddress arch) (PA.ConcreteAddress arch) (PA.ConcreteAddress arch)

--- a/src/Pate/Metrics.hs
+++ b/src/Pate/Metrics.hs
@@ -7,13 +7,10 @@ module Pate.Metrics (
   , summarize
   ) where
 
-import qualified Data.IntervalMap as IM
 import qualified Data.Macaw.BinaryLoader as MBL
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Memory as MM
 import qualified Data.Macaw.Memory.Permissions as MMP
-import qualified Data.Map.Strict as Map
-import           Data.Parameterized.Some ( Some(..) )
 import qualified Data.Time as TM
 
 import qualified Pate.Event as PE
@@ -57,8 +54,8 @@ loadedBinaryMetrics
   -> BinaryMetrics
 loadedBinaryMetrics le pfm =
   BinaryMetrics { executableBytes = byteCount
-                , numFunctions = length (IM.keys pfm)
-                , numBlocks = blockCount
+                , numFunctions = PMC.numParsedFunctions pfm
+                , numBlocks = PMC.numParsedBlocks pfm
                 }
   where
     isExec = MMP.isExecutable . MM.segmentFlags
@@ -67,12 +64,6 @@ loadedBinaryMetrics le pfm =
     byteCount = sum [ if isExec seg then fromIntegral (MM.segmentSize seg) else 0
                     | seg <- segs
                     ]
-
-    blockCount = sum [ length (IM.elems pbm)
-                     | bmap <- IM.elems pfm
-                     , Some (PMC.ParsedBlockMap pbm) <- Map.elems bmap
-                     ]
-
 
 
 -- | Summarize a single verifier event into the currently accumulated metrics

--- a/src/Pate/Monad/Context.hs
+++ b/src/Pate/Monad/Context.hs
@@ -1,18 +1,31 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Pate.Monad.Context (
     ParsedFunctionMap
-  , ParsedBlockMap(..)
+  , numParsedFunctions
+  , numParsedBlocks
+  , parsedFunctionEntries
+  , parsedFunctionContaining
+  , buildParsedFunctionMap
+
+  , ParsedBlockMap
+  , parsedBlocksContaining
+
   , BinaryContext(..)
   , EquivalenceContext(..)
   , currentFunc
   ) where
 
 
+import           Control.Lens ( (^.) )
 import qualified Control.Lens as L
 import           Data.IntervalMap (IntervalMap)
+import qualified Data.IntervalMap as IM
 import qualified Data.Map as Map
 import           Data.Parameterized.Some ( Some(..) )
 
@@ -36,7 +49,109 @@ newtype ParsedBlockMap arch ids = ParsedBlockMap
 -- | basic block extent -> function entry point -> basic block extent again -> parsed block
 --
 -- You should expect (and check) that exactly one key exists at the function entry point level.
-type ParsedFunctionMap arch = IntervalMap (PA.ConcreteAddress arch) (Map.Map (MM.ArchSegmentOff arch) (Some (ParsedBlockMap arch)))
+newtype ParsedFunctionMap arch = ParsedFunctionMap
+  { getParsedFunctionMap :: IntervalMap (PA.ConcreteAddress arch) (Map.Map (MM.ArchSegmentOff arch) (Some (ParsedBlockMap arch)))
+  }
+
+numParsedFunctions :: ParsedFunctionMap arch -> Int
+numParsedFunctions (ParsedFunctionMap pfm) = length (IM.keys pfm)
+
+numParsedBlocks :: ParsedFunctionMap arch -> Int
+numParsedBlocks (ParsedFunctionMap pfm) =
+   sum [ length (IM.elems pbm)
+       | bmap <- IM.elems pfm
+       , Some (ParsedBlockMap pbm) <- Map.elems bmap
+       ]
+
+-- | Return the list of entry points in the parsed function map
+parsedFunctionEntries :: ParsedFunctionMap arch -> [MM.ArchSegmentOff arch]
+parsedFunctionEntries = concatMap Map.keys . IM.elems . getParsedFunctionMap
+
+buildParsedFunctionMap :: forall arch.
+  MM.ArchConstraints arch =>
+  MD.DiscoveryState arch ->
+  ParsedFunctionMap arch
+buildParsedFunctionMap ds =
+  let fns = Map.assocs (ds ^. MD.funInfo)
+      xs = map processDiscoveryFunInfo fns
+   in ParsedFunctionMap (IM.unionsWith Map.union xs)
+
+ where
+  processDiscoveryFunInfo ::
+    (MM.ArchSegmentOff arch, Some (MD.DiscoveryFunInfo arch)) ->
+    IntervalMap (PA.ConcreteAddress arch) (Map.Map (MM.ArchSegmentOff arch) (Some (ParsedBlockMap arch)))
+  processDiscoveryFunInfo (entrySegOff, Some dfi) =
+    let blocks = buildParsedBlockMap dfi
+     in Map.singleton entrySegOff (Some blocks) <$ getParsedBlockMap blocks
+
+buildParsedBlockMap ::
+  MM.ArchConstraints arch =>
+  MD.DiscoveryFunInfo arch ids ->
+  ParsedBlockMap arch ids
+buildParsedBlockMap dfi = ParsedBlockMap . IM.fromListWith (++) $
+  [ (archSegmentOffToInterval blockSegOff (MD.blockSize pb), [pb])
+  | (blockSegOff, pb) <- Map.assocs (dfi ^. MD.parsedBlocks)
+  ]
+
+archSegmentOffToInterval ::
+  MM.ArchConstraints arch =>
+  MM.ArchSegmentOff arch ->
+  Int ->
+  IM.Interval (PA.ConcreteAddress arch)
+archSegmentOffToInterval segOff size =
+  let start = segOffToAddr segOff
+  in IM.IntervalCO start (start `PA.addressAddOffset` fromIntegral size)
+
+
+{- This doesn't seem to work correctly...
+parsedFunctionContaining ::
+  MM.ArchConstraints arch =>
+  PA.ConcreteAddress arch ->
+  ParsedFunctionMap arch ->
+  Either [MM.ArchSegmentOff arch] (MM.ArchSegmentOff arch, Some (ParsedBlockMap arch))
+parsedFunctionContaining addr (ParsedFunctionMap pfm) =
+  case Map.assocs $ Map.unions $ fmap snd $ IM.lookupLE i pfm of
+    [x]  -> Right x
+    blks -> Left (fst <$> blks)
+  where
+  start@(PA.ConcreteAddress saddr) = addr
+  end = PA.ConcreteAddress (MM.MemAddr (MM.addrBase saddr) maxBound)
+  i = IM.OpenInterval start end
+-}
+
+parsedFunctionContaining ::
+  MM.ArchConstraints arch =>
+  PA.ConcreteAddress arch ->
+  ParsedFunctionMap arch ->
+  Either [MM.ArchSegmentOff arch] (PA.ConcreteAddress arch, Some (ParsedBlockMap arch))
+parsedFunctionContaining addr (ParsedFunctionMap pfm) =
+  let fns = Map.assocs $ Map.unions $ fmap snd $ IM.lookupLE i pfm
+      fns' = fmap (\(segOff, pbm) -> (segOffToAddr segOff, pbm)) fns
+  in case reverse $ filter (\(addr', _) -> addr' <= start) fns' of
+       (x:_) -> Right x
+       [] -> Left (fst <$> fns)
+ where
+  start@(PA.ConcreteAddress saddr) = addr
+  end = PA.ConcreteAddress (MM.MemAddr (MM.addrBase saddr) maxBound)
+  i = IM.OpenInterval start end
+
+parsedBlocksContaining ::
+  MM.ArchConstraints arch =>
+  PA.ConcreteAddress arch ->
+  ParsedBlockMap arch ids ->
+  [MD.ParsedBlock arch ids]
+parsedBlocksContaining addr (ParsedBlockMap pbm) =
+    concat $ IM.elems $ IM.intersecting pbm i
+  where
+   start@(PA.ConcreteAddress saddr) = addr
+   end = PA.ConcreteAddress (MM.MemAddr (MM.addrBase saddr) maxBound)
+   i = IM.OpenInterval start end
+
+segOffToAddr ::
+  MM.ArchSegmentOff arch ->
+  PA.ConcreteAddress arch
+segOffToAddr off = PA.addressFromMemAddr (MM.segoffAddr off)
+
 
 data BinaryContext arch (bin :: PBi.WhichBinary) = BinaryContext
   { binary :: MBL.LoadedBinary arch (E.ElfHeaderInfo (MM.ArchAddrWidth arch))

--- a/src/Pate/Verification.hs
+++ b/src/Pate/Verification.hs
@@ -36,7 +36,6 @@ import qualified Control.Monad.IO.Unlift as IO
 import qualified Control.Monad.Reader as CMR
 import qualified Control.Monad.Trans as CMT
 import qualified Data.Foldable as F
-import qualified Data.IntervalMap as IM
 import qualified Data.Map as M
 import           Data.Maybe ( catMaybes )
 import qualified Data.Parameterized.Nonce as N
@@ -97,10 +96,6 @@ import qualified Pate.Verification.SymbolicExecution as PVSy
 import qualified Pate.Verification.Validity as PVV
 import           What4.ExprHelpers
 
--- | Return the list of entry points in the parsed function map
-parsedFunctionEntries :: PMC.ParsedFunctionMap arch -> [MM.ArchSegmentOff arch]
-parsedFunctionEntries = concatMap M.keys . IM.elems
-
 -- | Run code discovery using macaw
 --
 -- We run discovery in parallel, since we need to run it two to four times.
@@ -151,8 +146,8 @@ runDiscovery logAction mCFGDir elf elf' = do
                                     ]
                liftIO $ LJ.writeLog logAction (PE.FunctionEntryInvalidHints repr invalidEntries)
 
-             let unhintedDiscoveredAddresses = S.fromList (parsedFunctionEntries . PMC.parsedFunctionMap $ oCtxUnhinted)
-             let hintedDiscoveredAddresses = S.fromList (parsedFunctionEntries . PMC.parsedFunctionMap $ oCtxHinted)
+             let unhintedDiscoveredAddresses = S.fromList (PMC.parsedFunctionEntries (PMC.parsedFunctionMap oCtxUnhinted))
+             let hintedDiscoveredAddresses = S.fromList (PMC.parsedFunctionEntries (PMC.parsedFunctionMap oCtxHinted))
              let newAddrs = hintedDiscoveredAddresses `S.difference` unhintedDiscoveredAddresses
              unless (S.null newAddrs) $ do
                liftIO $ LJ.writeLog logAction (PE.FunctionsDiscoveredFromHints repr (F.toList newAddrs))


### PR DESCRIPTION
the `Pate.Monad.Context` module; various rewrites/simplifications
of the same.