### PR TITLE
Tr/incremental code discovery

### DIFF
--- a/pate.cabal
+++ b/pate.cabal
@@ -92,6 +92,7 @@ library
                        Pate.Monad.Context,
                        Pate.Monad.Environment,
                        Pate.MemCell,
+                       Pate.Memory,
                        Pate.Memory.MemTrace,
                        Pate.Metrics,
                        Pate.SimulatorRegisters,

--- a/src/Pate/Event.hs
+++ b/src/Pate/Event.hs
@@ -25,7 +25,6 @@ import qualified Pate.Block as PB
 import qualified Pate.Hints.CSV as PHC
 import qualified Pate.Hints.DWARF as PHD
 import qualified Pate.Hints.JSON as PHJ
-import qualified Pate.Monad.Context as PMC
 import qualified Pate.Proof as PF
 import qualified Pate.Proof.Instances as PFI
 import qualified Pate.PatchPair as PPa
@@ -71,10 +70,7 @@ data Event arch where
   ComputedPrecondition :: BlocksPair arch -> TM.NominalDiffTime -> Event arch
   ElfLoaderWarnings :: [DEE.ElfParseError] -> Event arch
   CheckedEquivalence :: BlocksPair arch -> EquivalenceResult arch -> TM.NominalDiffTime -> Event arch
-  LoadedBinaries ::
-    (PLE.LoadedELF arch, PMC.ParsedFunctionMap arch PB.Original) ->
-    (PLE.LoadedELF arch, PMC.ParsedFunctionMap arch PB.Patched) ->
-    Event arch
+  LoadedBinaries :: PLE.LoadedELF arch -> PLE.LoadedELF arch -> Event arch
   -- | Function/block start hints that point to unmapped addresses
   FunctionEntryInvalidHints :: PB.WhichBinaryRepr bin -> [(T.Text, Word64)] -> Event arch
   -- | A list of functions discovered from provided hints that macaw code

--- a/src/Pate/Interactive.hs
+++ b/src/Pate/Interactive.hs
@@ -108,9 +108,9 @@ consumeEvents chan r0 verb mTraceHandle = do
         Just hdl -> PPRT.hPutDoc hdl (traceFormatEvent evt)
 
       case evt of
-        PE.LoadedBinaries (oelf, omap) (pelf, pmap) -> do
-          IOR.atomicModifyIORef' (stateRef r0) $ \s -> (s & originalBinary .~ Just (oelf, omap)
-                                                          & patchedBinary .~ Just (pelf, pmap), ())
+        PE.LoadedBinaries oelf pelf -> do
+          IOR.atomicModifyIORef' (stateRef r0) $ \s -> (s & originalBinary .~ Just oelf
+                                                          & patchedBinary .~ Just pelf, ())
         PE.ElfLoaderWarnings {} ->
           IOR.atomicModifyIORef' (stateRef r0) $ \s -> (s & recentEvents %~ addRecent recentEventCount evt, ())
         PE.CheckedEquivalence bpair@(PPa.PatchPair (PE.Blocks blk _) _) res duration -> do
@@ -350,7 +350,7 @@ binaryStats
 binaryStats st accessor label = do
   bm <- st ^. metrics . L.to accessor
   return [ TP.bold #+ [TP.string (label ++ " Binary Stats")]
-         , TP.string ("Size (bytes): " ++ show (PM.executableBytes bm) ++ " / # Functions: " ++ show (PM.numFunctions bm) ++ " / # Blocks: " ++ show (PM.numBlocks bm))
+         , TP.string ("Size (bytes): " ++ show (PM.executableBytes bm))
          ]
 
 {- Note [Monitoring Proof Construction and Evaluation]

--- a/src/Pate/Interactive/Render/BlockPairDetail.hs
+++ b/src/Pate/Interactive/Render/BlockPairDetail.hs
@@ -42,11 +42,11 @@ renderCounterexample er =
 renderSource :: (PAr.ArchConstraints arch)
              => IS.State arch
              -> (IS.SourcePair LC.CTranslUnit -> LC.CTranslUnit)
-             -> L.Getter (IS.State arch) (Maybe (PLE.LoadedELF arch, b))
+             -> L.Getter (IS.State arch) (Maybe (PLE.LoadedELF arch))
              -> MC.MemAddr (MC.ArchAddrWidth arch)
              -> [TP.UI TP.Element]
 renderSource st getSource binL addr = fromMaybe [] $ do
-  (lelf, _) <- st ^. binL
+  lelf <- st ^. binL
   bname <- MBL.symbolFor (PLE.loadedBinary lelf) addr
   let sname = UTF8.toString (UTF8.fromRep bname)
   LC.CTranslUnit decls _ <- getSource <$> st ^. IS.sources
@@ -69,7 +69,7 @@ renderFunctionName :: (PAr.ArchConstraints arch)
                    -> MC.MemAddr (MC.ArchAddrWidth arch)
                    -> [TP.UI TP.Element]
 renderFunctionName st origAddr = fromMaybe [] $ do
-  (lelf, _) <- st ^. IS.originalBinary
+  lelf <- st ^. IS.originalBinary
   bname <- MBL.symbolFor (PLE.loadedBinary lelf) origAddr
   let sname = UTF8.toString (UTF8.fromRep bname)
   return [TP.string ("(Function: " ++ sname ++ ")")]

--- a/src/Pate/Interactive/State.hs
+++ b/src/Pate/Interactive/State.hs
@@ -41,11 +41,9 @@ import qualified What4.Expr as WE
 import qualified What4.Interface as WI
 
 import qualified Pate.Address as PA
-import qualified Pate.Binary as PB
 import qualified Pate.Event as PE
 import qualified Pate.Loader.ELF as PLE
 import qualified Pate.Metrics as PM
-import qualified Pate.Monad.Context as PMC
 import qualified Pate.Proof as PPr
 import qualified Pate.Proof.Instances as PFI
 import qualified Pate.Solver as PS
@@ -96,8 +94,8 @@ data State arch =
         , _failure :: Map.Map (PA.ConcreteAddress arch) (Failure arch)
         , _recentEvents :: [PE.Event arch]
         -- ^ The N most recent events (most recent first), to be shown in the console
-        , _originalBinary :: Maybe (PLE.LoadedELF arch, PMC.ParsedFunctionMap arch PB.Original)
-        , _patchedBinary :: Maybe (PLE.LoadedELF arch, PMC.ParsedFunctionMap arch PB.Patched)
+        , _originalBinary :: Maybe (PLE.LoadedELF arch)
+        , _patchedBinary :: Maybe (PLE.LoadedELF arch)
         , _sources :: Maybe (SourcePair LC.CTranslUnit)
         , _proofTree :: Maybe (ProofTree arch)
         -- ^ All of the collected proof nodes received from the verifier

--- a/src/Pate/Memory.hs
+++ b/src/Pate/Memory.hs
@@ -1,0 +1,32 @@
+module Pate.Memory (
+  resolveAbsoluteAddress
+  ) where
+
+import           Data.Maybe ( listToMaybe )
+import qualified Data.Macaw.Memory as MM
+
+-- | Resolve a 'MM.MemWord', interpreted as an absolute address, into a 'MM.MemSegmentOff'
+--
+-- This is useful for resolving the entry point of a binary into a macaw
+-- address.  At the level of an ELF file (or other executable container),
+-- addresses are given as "absolute" addresses.  This is a bit of a convenient
+-- fiction as the real address cannot be known until load time when the OS (or
+-- bootleader) maps the executable into memory at some offset.  In some sense,
+-- all of the addresses given in the executable container are *offsets from an abstract base*.
+--
+-- Macaw loads dynamically linked and statically linked binaries slightly
+-- differently, where addresses in the statically linked case are all "absolute"
+-- with region number 0.  Dynamically linked executables have a different region
+-- number.  This function searches for the segment containing the ostensibly
+-- absolute address and converts it into a 'MM.MemSegmentOff'.
+resolveAbsoluteAddress
+  :: (MM.MemWidth w)
+  => MM.Memory w
+  -> MM.MemWord w
+  -> Maybe (MM.MemSegmentOff w)
+resolveAbsoluteAddress mem addr =
+  listToMaybe [ segOff
+              | seg <- MM.memSegments mem
+              , let region = MM.segmentBase seg
+              , Just segOff <- return (MM.resolveRegionOff mem region addr)
+              ]

--- a/src/Pate/Monad/Context.hs
+++ b/src/Pate/Monad/Context.hs
@@ -2,20 +2,15 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Pate.Monad.Context (
     ParsedFunctionMap
-  , numParsedFunctions
-  , numParsedBlocks
-  , parsedFunctionEntries
+  , newParsedFunctionMap
   , parsedFunctionContaining
-  , buildParsedFunctionMap
-  , buildFunctionEntryMap
-
   , ParsedBlocks(..)
-
   , BinaryContext(..)
   , EquivalenceContext(..)
   , currentFunc
@@ -24,10 +19,19 @@ module Pate.Monad.Context (
 
 import           Control.Lens ( (^.) )
 import qualified Control.Lens as L
+import qualified Data.Foldable as F
+import qualified Data.IORef as IORef
 import qualified Data.Map as Map
+import qualified Data.Parameterized.Classes as PC
 import           Data.Parameterized.Some ( Some(..) )
+import qualified Prettyprinter as PP
+import qualified Prettyprinter.Render.Text as PPT
+import qualified System.Directory as SD
+import           System.FilePath ( (</>), (<.>) )
+import qualified System.IO as IO
 
 import qualified Data.ElfEdit as E
+import qualified Data.Macaw.Architecture.Info as MAI
 import qualified Data.Macaw.BinaryLoader as MBL
 import qualified Data.Macaw.CFG as MM
 import qualified Data.Macaw.Discovery as MD
@@ -42,44 +46,42 @@ import qualified Pate.PatchPair as PPa
 
 data ParsedBlocks arch = forall ids. ParsedBlocks [MD.ParsedBlock arch ids]
 
-newtype ParsedFunctionMap arch bin =
-  ParsedFunctionMap (Map.Map (PB.FunctionEntry arch bin) (ParsedBlocks arch))
+data ParsedFunctionState arch bin =
+  ParsedFunctionState { parsedFunctionCache :: Map.Map (PB.FunctionEntry arch bin) (ParsedBlocks arch)
+                      , discoveryState :: MD.DiscoveryState arch
+                      }
 
-numParsedFunctions :: ParsedFunctionMap arch bin -> Int
-numParsedFunctions (ParsedFunctionMap pfm) = Map.size pfm
+-- | A (lazily constructed) map of function entry points to the blocks for that function
+--
+-- Think of this as a cache of discovered functions, with some of the extra
+-- macaw metadata (e.g., the enclosing DiscoveryFunInfo) discarded
+data ParsedFunctionMap arch bin =
+  ParsedFunctionMap { parsedStateRef :: IORef.IORef (ParsedFunctionState arch bin)
+                    -- ^ State that is updated on-demand
+                    , persistenceDir :: Maybe FilePath
+                    -- ^ The directory to save discovered CFGs to, if present
+                    }
 
-numParsedBlocks :: ParsedFunctionMap arch bin -> Int
-numParsedBlocks (ParsedFunctionMap pfm) =
-   sum [ length pbs | ParsedBlocks pbs <- Map.elems pfm ]
-
--- | Return the list of entry points in the parsed function map
-parsedFunctionEntries :: ParsedFunctionMap arch bin -> [PB.FunctionEntry arch bin]
-parsedFunctionEntries (ParsedFunctionMap pfm) = Map.keys pfm
-
-buildParsedFunctionMap :: forall arch bin.
-  MM.ArchConstraints arch =>
-  PBi.KnownBinary bin =>
-  MD.DiscoveryState arch ->
-  ParsedFunctionMap arch bin
-buildParsedFunctionMap ds =
-  let fns = Map.assocs (ds ^. MD.funInfo)
-      xs = map processDiscoveryFunInfo fns
-   in ParsedFunctionMap (Map.fromList xs)
- where
-  processDiscoveryFunInfo (_entrySegOff, Some dfi) =
-    (funInfoToFunEntry W4.knownRepr dfi, buildParsedBlocks dfi)
-
-buildParsedBlocks :: MD.DiscoveryFunInfo arch ids -> ParsedBlocks arch
-buildParsedBlocks dfi = ParsedBlocks (Map.elems (dfi ^. MD.parsedBlocks))
-
-buildFunctionEntryMap ::
-  PBi.WhichBinaryRepr bin ->
-  Map.Map (MM.ArchSegmentOff arch) (Some (MD.DiscoveryFunInfo arch)) ->
-  Map.Map (PA.ConcreteAddress arch) (PB.FunctionEntry arch bin)
-buildFunctionEntryMap binRepr disMap = Map.fromList
-  [ (PA.segOffToAddr segOff, funInfoToFunEntry binRepr fi)
-  | (segOff, Some fi) <- Map.assocs disMap
-  ]
+-- | Allocate a new empty 'ParsedFunctionMap'
+newParsedFunctionMap
+  :: MM.Memory (MM.ArchAddrWidth arch)
+  -- ^ The binary memory
+  -> MD.AddrSymMap (MM.ArchAddrWidth arch)
+  -- ^ Symbols assigned to addresses by metadata
+  -> MAI.ArchitectureInfo arch
+  -- ^ Architecture-specific code discovery information and configuration
+  -> Maybe FilePath
+  -- ^ The path to save discovered CFGs to, if present
+  -> IO (ParsedFunctionMap arch bin)
+newParsedFunctionMap mem syms archInfo mCFGDir = do
+  ref <- IORef.newIORef s0
+  return ParsedFunctionMap { parsedStateRef = ref
+                           , persistenceDir = mCFGDir
+                           }
+  where
+    s0 = ParsedFunctionState { parsedFunctionCache = mempty
+                             , discoveryState = MD.emptyDiscoveryState mem syms archInfo
+                             }
 
 funInfoToFunEntry ::
   PBi.WhichBinaryRepr bin ->
@@ -92,13 +94,89 @@ funInfoToFunEntry binRepr dfi =
   , PB.functionBinRepr = binRepr
   }
 
+buildParsedBlocks :: MD.DiscoveryFunInfo arch ids -> ParsedBlocks arch
+buildParsedBlocks dfi = ParsedBlocks (Map.elems (dfi ^. MD.parsedBlocks))
+
+-- | Write the macaw CFG for the given discovered function to disk if we are
+-- given a directory to store it in.
+--
+-- Note that this directory is the *base* directory; we use the type repr for
+-- the binary (original vs patched) to ensure that we don't overwrite results
+-- from different binaries on disk.
+saveCFG
+  :: (MM.ArchConstraints arch)
+  => Maybe FilePath
+  -> PBi.WhichBinaryRepr bin
+  -> MD.DiscoveryFunInfo arch ids
+  -> IO ()
+saveCFG mCFGDir repr dfi =
+  F.forM_ mCFGDir $ \cfgDir -> do
+    let baseDir = cfgDir </> show repr
+    SD.createDirectoryIfMissing True baseDir
+    let fname = baseDir </> show (MD.discoveredFunAddr dfi) <.> "cfg"
+    IO.withFile fname IO.WriteMode $ \hdl -> do
+      PPT.hPutDoc hdl (PP.pretty dfi)
+
+-- | Return the basic blocks corresponding to the function that contains the
+-- given basic block
+--
+-- This will return a cached parsed function if possible, or run the macaw
+-- analysis on a new address and cache the result.
+--
+-- This function will return 'Nothing' if the address it is provided (via the
+-- 'PB.ConcreteBlock') is not a mapped address in the binary. As long as the
+-- address is valid, this function will at *least* return a single block with a
+-- macaw translation error.
 parsedFunctionContaining ::
-  MM.ArchConstraints arch =>
+  forall bin arch .
+  (PBi.KnownBinary bin, MM.ArchConstraints arch) =>
   PB.ConcreteBlock arch bin ->
   ParsedFunctionMap arch bin ->
-  Maybe (ParsedBlocks arch)
-parsedFunctionContaining blk (ParsedFunctionMap pfm) =
-  Map.lookup (PB.blockFunctionEntry blk) pfm
+  IO (Maybe (ParsedBlocks arch))
+parsedFunctionContaining blk (ParsedFunctionMap pfmRef mCFGDir) = do
+  let baddr = PA.addrToMemAddr (PB.concreteAddress blk)
+  st <- IORef.readIORef pfmRef
+  let ds1 = discoveryState st
+  let mem = MD.memory ds1
+  -- First, check if we have a cached set of blocks for this state
+  case Map.lookup (PB.blockFunctionEntry blk) (parsedFunctionCache st) of
+    Just blks -> return (Just blks)
+    Nothing -> do
+      -- Otherwise, run code discovery at this address
+      case MM.resolveRegionOff mem (MM.addrBase baddr) (MM.addrOffset baddr) of
+        Nothing -> return Nothing -- This could be an exception... but perhaps better as a proof failure node
+        Just faddr -> do
+          -- NOTE: We are using the strict atomic modify IORef here. The code is
+          -- not attempting to force the modified state or returned function to
+          -- normal form.
+          --
+          -- It isn't clear if this will be a problem in practice or not. We
+          -- think that the worst case is that we end up with thunks in the
+          -- IORef that might be evaluated multiple times if there is a lot of
+          -- contention. If that becomes a problem, we may want to change this
+          -- to an MVar where we fully evaluate each result before updating it.
+          (Some dfi, blks) <- IORef.atomicModifyIORef' pfmRef (atomicAnalysis faddr)
+          let binRep :: PBi.WhichBinaryRepr bin
+              binRep = PC.knownRepr
+          saveCFG mCFGDir binRep dfi
+          return (Just blks)
+  where
+    -- The entire analysis is bundled up in here so that we can issue an atomic
+    -- update to the cache that preserves the discovery state. If we didn't do
+    -- the analysis inside of the atomic update, we might lose updates to the
+    -- discovery state. While that is not very important for our use case (we
+    -- don't care about the preserved discovery state), it seems morally better
+    -- to not lose those updates.
+    atomicAnalysis faddr st =
+      let rsn = MD.CallTarget faddr
+      in case MD.analyzeFunction faddr rsn (discoveryState st) of
+           (ds2, Some dfi) ->
+             let entry = funInfoToFunEntry W4.knownRepr dfi
+                 pbs = buildParsedBlocks dfi
+             in (st { parsedFunctionCache = Map.insert entry pbs (parsedFunctionCache st)
+                    , discoveryState = ds2
+                    }, (Some dfi, pbs))
+
 
 data BinaryContext arch (bin :: PBi.WhichBinary) = BinaryContext
   { binary :: MBL.LoadedBinary arch (E.ElfHeaderInfo (MM.ArchAddrWidth arch))
@@ -116,9 +194,6 @@ data BinaryContext arch (bin :: PBi.WhichBinary) = BinaryContext
   , binAbortFn :: Maybe (PB.FunctionEntry arch bin)
   -- ^ address of special-purposes "abort" function that represents an abnormal
   -- program exit
-
-  , functionEntryMap :: Map.Map (PA.ConcreteAddress arch) (PB.FunctionEntry arch bin)
-  -- ^ A map of all the function entrypoints we know about
   }
 
 data EquivalenceContext sym arch where

--- a/src/Pate/Panic.hs
+++ b/src/Pate/Panic.hs
@@ -9,6 +9,7 @@ import qualified Panic as P
 data PateComponent = Verifier
                    | Visualizer
                    | ProofConstruction
+                   | Discovery
                    deriving (Show)
 
 instance P.PanicComponent PateComponent where


### PR DESCRIPTION
Previously, we used macaw to eagerly run code discovery and analyze all of the
code that we could find. This was problematic for large binaries, for which we
ran out of memory. The memory expansion of macaw IR (and Crucible) compared to
machine code is enormous (probably over 1000x).

With this change, we now only run code discovery on demand (i.e., when we find a
call to a function, we analyze just that function).  We cache analyzed
functions for easy access.  Note that cache currently only grows; it could
trivially become an LRU cache if desired.

An unfortunate side effect of this change is that we can do a bit less in the
way of diagnostics. Before, we were able to figure out which hints from users
were incorrect (i.e., inconsistent with analysis results). Now that we only
lazily find code, we can't do that anymore. Some of our diagnostics and metrics
are less precise now.

Closes #155