### PR TITLE
Render the InlineCallee nodes in the UI

### DIFF
--- a/arch/Pate/PPC.hs
+++ b/arch/Pate/PPC.hs
@@ -93,7 +93,7 @@ getCurrentTOC
   -> PB.WhichBinaryRepr bin
   -> IO (W.W 64)
 getCurrentTOC ctx binRepr = do
-  PE.Blocks _ (pblk:_) <- PPa.getPair' binRepr <$> PD.getBlocks' ctx (ctx ^. PMC.currentFunc)
+  PE.Blocks _ _ (pblk:_) <- PPa.getPair' binRepr <$> PD.getBlocks' ctx (ctx ^. PMC.currentFunc)
   let
     toc = TOC.getTOC (PMC.binary $ PPa.getPair' binRepr (PMC.binCtxs ctx))
     addr = MD.pblockAddr pblk

--- a/src/Pate/Discovery.hs
+++ b/src/Pate/Discovery.hs
@@ -506,8 +506,8 @@ getBlocks' ctx pPair = do
   bs2 <- liftIO $ lookupBlocks' ctxP blkP
   case (bs1, bs2) of
     (Right (PMC.ParsedBlocks opbs), Right (PMC.ParsedBlocks ppbs)) -> do
-      let oBlocks = PE.Blocks blkO opbs
-      let pBlocks = PE.Blocks blkP ppbs
+      let oBlocks = PE.Blocks PC.knownRepr blkO opbs
+      let pBlocks = PE.Blocks PC.knownRepr blkP ppbs
       return $! PPa.PatchPair oBlocks pBlocks
     (Left err, _) -> CMC.throwM err
     (_, Left err) -> CMC.throwM err
@@ -524,9 +524,9 @@ getBlocks ::
   EquivM sym arch (PE.BlocksPair arch)
 getBlocks pPair = do
   PMC.ParsedBlocks opbs <- lookupBlocks blkO
-  let oBlocks = PE.Blocks blkO opbs
+  let oBlocks = PE.Blocks PC.knownRepr blkO opbs
   PMC.ParsedBlocks ppbs <- lookupBlocks blkP
-  let pBlocks = PE.Blocks blkP ppbs
+  let pBlocks = PE.Blocks PC.knownRepr blkP ppbs
   return $ PPa.PatchPair oBlocks pBlocks
   where
     blkO = PPa.pOriginal pPair

--- a/src/Pate/Event.hs
+++ b/src/Pate/Event.hs
@@ -11,7 +11,9 @@ module Pate.Event (
 
 import qualified Data.ElfEdit as DEE
 import qualified Data.List.NonEmpty as DLN
+import qualified Data.Macaw.CFG as DMC
 import qualified Data.Macaw.Discovery as MD
+import qualified Data.Parameterized.NatRepr as PN
 import qualified Data.Text as T
 import qualified Data.Time as TM
 import           Data.Word ( Word64 )
@@ -34,7 +36,7 @@ import qualified Pate.Loader.ELF as PLE
 
 -- | The macaw blocks relevant for a given code address
 data Blocks arch bin where
-  Blocks :: PB.ConcreteBlock arch bin -> [MD.ParsedBlock arch ids] -> Blocks arch bin
+  Blocks :: PN.NatRepr (DMC.ArchAddrWidth arch) -> PB.ConcreteBlock arch bin -> [MD.ParsedBlock arch ids] -> Blocks arch bin
 
 type BlocksPair arch = PPa.PatchPair (Blocks arch)
 

--- a/src/Pate/Interactive.hs
+++ b/src/Pate/Interactive.hs
@@ -113,7 +113,7 @@ consumeEvents chan r0 verb mTraceHandle = do
                                                           & patchedBinary .~ Just pelf, ())
         PE.ElfLoaderWarnings {} ->
           IOR.atomicModifyIORef' (stateRef r0) $ \s -> (s & recentEvents %~ addRecent recentEventCount evt, ())
-        PE.CheckedEquivalence bpair@(PPa.PatchPair (PE.Blocks blk _) _) res duration -> do
+        PE.CheckedEquivalence bpair@(PPa.PatchPair (PE.Blocks _ blk _) _) res duration -> do
           let
             addr = PB.concreteAddress blk
             et = EquivalenceTest bpair duration

--- a/src/Pate/Interactive/Render/BlockPairDetail.hs
+++ b/src/Pate/Interactive/Render/BlockPairDetail.hs
@@ -84,7 +84,7 @@ renderBlockPairDetail
   -> PE.Blocks arch PB.Patched
   -> Maybe (PE.EquivalenceResult arch)
   -> TP.UI (TP.Element, TP.UI (), TP.UI ())
-renderBlockPairDetail st o@(PE.Blocks blkO _opbs) p@(PE.Blocks blkP _ppbs) res = do
+renderBlockPairDetail st o@(PE.Blocks _ blkO _opbs) p@(PE.Blocks _ blkP _ppbs) res = do
   g <- TP.grid [ maybe [] renderCounterexample res
                , concat [[renderAddr "Original Code" origAddr, renderAddr "Patched Code" patchedAddr], renderFunctionName st origAddr]
                , concat [ renderSource st IS.originalSource IS.originalBinary origAddr

--- a/src/Pate/Interactive/Render/Console.hs
+++ b/src/Pate/Interactive/Render/Console.hs
@@ -78,6 +78,7 @@ renderProofApp app =
     PPr.ProofTriple {} -> TP.string "ProofTriple"
     PPr.ProofStatus vs -> TP.string ("ProofStatus=" ++ verificationStatusTag vs)
     PPr.ProofDomain {} -> TP.string "ProofDomain"
+    PPr.ProofInlinedCall {} -> TP.string "InlinedCall"
 
 renderEvent :: (PA.ValidArch arch) => IS.State arch -> TP.Element -> PE.Event arch -> TP.UI TP.Element
 renderEvent st detailDiv evt =
@@ -85,7 +86,7 @@ renderEvent st detailDiv evt =
     PE.LoadedBinaries {} -> TP.string "Loaded original and patched binaries"
     PE.ElfLoaderWarnings pes ->
       TP.ul #+ (map (\w -> TP.li #+ [TP.string (show w)]) pes)
-    PE.CheckedEquivalence (PPa.PatchPair ob@(PE.Blocks blkO _) pb@(PE.Blocks blkP _)) res duration -> do
+    PE.CheckedEquivalence (PPa.PatchPair ob@(PE.Blocks _ blkO _) pb@(PE.Blocks _ blkP _)) res duration -> do
       let
         origAddr = PB.blockMemAddr blkO
         patchedAddr = PB.blockMemAddr blkP
@@ -99,7 +100,7 @@ renderEvent st detailDiv evt =
                  , TP.string (" (in " ++ show duration ++ ")")
                  , renderEquivalenceResult res
                  ]
-    PE.ProofIntermediate (PPa.PatchPair ob@(PE.Blocks blkO _) pb@(PE.Blocks _blkP _))
+    PE.ProofIntermediate (PPa.PatchPair ob@(PE.Blocks _ blkO _) pb@(PE.Blocks _ _blkP _))
                          (PFI.SomeProofSym _ (PPr.ProofNonceExpr nonce (Some parentNonce) app)) duration -> do
       let origAddr = PB.blockMemAddr blkO
       blockLink <- TP.a # TP.set TP.text (show origAddr)

--- a/src/Pate/Interactive/Render/SliceGraph.hs
+++ b/src/Pate/Interactive/Render/SliceGraph.hs
@@ -90,7 +90,7 @@ renderSliceGraph
   => String
   -> PE.Blocks arch bkind
   -> (TP.UI TP.Element, TP.UI ())
-renderSliceGraph divId (PE.Blocks _ parsedBlocks) =
+renderSliceGraph divId (PE.Blocks _ _ parsedBlocks) =
   (TP.div # TP.set TP.id_ divId, TP.runFunction (initializeGraph divId (JSON.Object graph)))
   where
     nodes = F.foldl' blockNode Map.empty parsedBlocks

--- a/src/Pate/Proof.hs
+++ b/src/Pate/Proof.hs
@@ -254,7 +254,7 @@ data ProofApp prf (node :: ProofNodeType -> DK.Type) (tp :: ProofNodeType) where
   -- the two programs execute
   ProofInlinedCall ::
     { prfInlinedBlocks :: PPa.PatchPair (ProofBlock prf)
-    , prfInlinedResults :: ProofInlinedResult prf
+    , prfInlinedResults :: Either String (ProofInlinedResult prf)
     } -> ProofApp prf node ProofBlockSliceType
 
   -- | Proof that a function call is valid. Specifically, if a function 'g' is called from

--- a/tools/pate/Main.hs
+++ b/tools/pate/Main.hs
@@ -340,7 +340,7 @@ terminalFormatEvent evt =
                        , PP.viaShow $ PB.concreteAddress blkP
                        , PP.line
                        ]
-    PE.CheckedEquivalence (PPa.PatchPair (PE.Blocks blkO _) (PE.Blocks blkP _)) res duration ->
+    PE.CheckedEquivalence (PPa.PatchPair (PE.Blocks _ blkO _) (PE.Blocks _ blkP _)) res duration ->
       let
         origAddr = PB.concreteAddress blkO
         patchedAddr = PB.concreteAddress blkP


### PR DESCRIPTION
This fills in the missing rendering cases and handles symbolic execution
features in the InlineCallee feature

Fixes #162