### PR TITLE
Be more explicit about handling of encoding and terminal properties

### DIFF
--- a/pate.cabal
+++ b/pate.cabal
@@ -247,6 +247,7 @@ executable pate-exec
                        prettyprinter,
                        prettyprinter-ansi-terminal >= 1.1 && < 1.2,
                        time,
+                       ansi-terminal >= 0.7 && < 0.12,
                        ansi-wl-pprint,
                        lumberjack >= 0.1 && < 1.1,
                        threepenny-gui >= 0.9 && < 0.10,


### PR DESCRIPTION
In the Docker image, the default encoding is unclear. The Dockerfile attempts to
set everything to UTF8, but it apparently does not succeed. Logging to a file in
the Docker image causes something in the GHC RTS to raise an encoding exception.

This change explicitly sets the encoding of the output file to UTF-8.  This
change is also more careful to not emit ANSI escapes when not outputting to a
terminal.