### PR TITLE
Add abstraction for memory model representation

### DIFF
--- a/src/Pate/Discovery.hs
+++ b/src/Pate/Discovery.hs
@@ -166,7 +166,7 @@ exactEquivalence inO inP = withSym $ \sym -> do
     True -> return ()
     False -> CME.fail "exactEquivalence: regsEq: assumed false"
 
-  memEq <- liftIO $ WI.isEq sym (MT.memArr (PSS.simInMem inO)) (MT.memArr (PSS.simInMem inP))
+  memEq <- liftIO $ MT.memEqExact sym (MT.memState $ PSS.simInMem inO) (MT.memState $ PSS.simInMem inP)
 
   isPredSat heuristicTimeout memEq >>= \case
     True -> return ()

--- a/src/Pate/MemCell.hs
+++ b/src/Pate/MemCell.hs
@@ -216,8 +216,8 @@ writeMemCell ::
   IsSymInterface sym =>
   MC.RegisterInfo (MC.ArchReg arch) =>
   sym ->
+  -- | write condition
   WI.Pred sym ->
-  -- ^ write condition
   PMT.MemTraceState sym (MC.ArchAddrWidth arch) ->
   MemCell sym arch w ->
   CLM.LLVMPtr sym (8 WI.* w) ->

--- a/src/Pate/MemCell.hs
+++ b/src/Pate/MemCell.hs
@@ -21,6 +21,7 @@ module Pate.MemCell (
 
 import           Control.Monad ( foldM, forM )
 
+
 import qualified Data.Macaw.CFG.Core as MC
 import qualified Data.Macaw.Memory as MM
 import qualified Data.Map.Strict as Map
@@ -31,6 +32,7 @@ import qualified Data.Parameterized.NatRepr as PNR
 import qualified Data.Parameterized.TraversableF as TF
 import           GHC.TypeLits ( type (<=) )
 import qualified Lang.Crucible.LLVM.MemModel as CLM
+import           Lang.Crucible.Backend (IsSymInterface)
 import qualified What4.Interface as WI
 
 import qualified Pate.ExprMappable as PEM
@@ -202,27 +204,27 @@ readMemCell ::
   WI.IsSymExprBuilder sym =>
   MC.RegisterInfo (MC.ArchReg arch) =>
   sym ->
-  PMT.MemTraceImpl sym (MC.ArchAddrWidth arch) ->
+  PMT.MemTraceState sym (MC.ArchAddrWidth arch) ->
   MemCell sym arch w ->
   IO (CLM.LLVMPtr sym (8 WI.* w))
 readMemCell sym mem cell@(MemCell{}) = do
   let repr = MC.BVMemRepr (cellWidth cell) (cellEndian cell)
-  PMT.readMemArr sym mem (cellPtr cell) repr
+  PMT.readMemState sym mem (cellPtr cell) repr
 
 -- FIXME: this currently drops the region due to weaknesses in the memory model
 writeMemCell ::
-  WI.IsSymExprBuilder sym =>
+  IsSymInterface sym =>
   MC.RegisterInfo (MC.ArchReg arch) =>
   sym ->
-  PMT.MemTraceImpl sym (MC.ArchAddrWidth arch) ->
+  WI.Pred sym ->
+  -- ^ write condition
+  PMT.MemTraceState sym (MC.ArchAddrWidth arch) ->
   MemCell sym arch w ->
   CLM.LLVMPtr sym (8 WI.* w) ->
-  IO (PMT.MemTraceImpl sym (MC.ArchAddrWidth arch))
-writeMemCell sym mem cell@(MemCell{}) valPtr = do
-  let
-    repr = MC.BVMemRepr (cellWidth cell) (cellEndian cell)
-    CLM.LLVMPointer _ val = valPtr
-  PMT.writeMemArr sym mem (cellPtr cell) repr val
+  IO (PMT.MemTraceState sym (MC.ArchAddrWidth arch))
+writeMemCell sym cond mem cell@(MemCell{}) valPtr = do
+  let repr = MC.BVMemRepr (cellWidth cell) (cellEndian cell)
+  PMT.writeMemState sym cond mem (cellPtr cell) repr valPtr
 
 instance PEM.ExprMappable sym (MemCell sym arch w) where
   mapExpr sym f (MemCell ptr w end) = do

--- a/src/Pate/Memory/MemTrace.hs
+++ b/src/Pate/Memory/MemTrace.hs
@@ -28,11 +28,11 @@
 
 module Pate.Memory.MemTrace
 ( MemTraceImpl(..)
-, MemTraceVar(..)
+, MemTraceState
 , MemTrace
 , llvmPtrEq
-, readMemArr
-, writeMemArr
+, readMemState
+, writeMemState
 , MemFootprint(..)
 , MemOpDirection(..)
 , getCond
@@ -41,7 +41,6 @@ module Pate.Memory.MemTrace
 , UndefPtrOpTag
 , UndefPtrOpTags
 , UndefinedPtrOps(..)
-, initMemTraceVar
 , MemOpCondition(..)
 , MemOp(..)
 , flatMemOps
@@ -49,8 +48,12 @@ module Pate.Memory.MemTrace
 , initMemTrace
 , classifyExpr
 , mkMemTraceVar
+, mkMemoryBinding
 , mkUndefinedPtrOps
 , macawTraceExtensions
+, memEqOutsideRegion
+, memEqAtRegion
+, memEqExact
 ) where
 
 import Unsafe.Coerce
@@ -73,7 +76,7 @@ import qualified Data.Parameterized.Context as Ctx
 
 import qualified Data.Macaw.Types as MT
 import Data.Macaw.CFG.AssignRhs (ArchAddrWidth, MemRepr(..))
-import Data.Macaw.Memory (AddrWidthRepr(..), Endianness(..), MemWidth, addrWidthClass, addrWidthNatRepr)
+import Data.Macaw.Memory (AddrWidthRepr(..), Endianness(..), MemWidth, addrWidthClass, addrWidthRepr, addrWidthNatRepr)
 import Data.Macaw.Symbolic.Backend (MacawEvalStmtFunc, MacawArchEvalFn(..))
 import Data.Macaw.Symbolic ( MacawStmtExtension(..), MacawExprExtension(..), MacawExt
                            , GlobalMap, MacawSimulatorState(..)
@@ -504,11 +507,12 @@ instance TestEquality (SymExpr sym) => Eq (MemOp sym ptrW) where
 data MemTraceImpl sym ptrW = MemTraceImpl
   { memSeq :: MemTraceSeq sym ptrW
   -- ^ the sequence of memory operations in execution order
-  , memArr :: MemTraceArr sym ptrW
+  , memState :: MemTraceState sym ptrW
   -- ^ the logical contents of memory
   }
 
-data MemTraceVar sym ptrW = MemTraceVar (SymExpr sym (MemArrBaseType ptrW))
+data MemTraceState sym ptrW = MemTraceState
+  { memArr :: MemTraceArr sym ptrW }
 
 type MemTraceSeq sym ptrW = Seq (MemOp sym ptrW)
 type MemTraceArr sym ptrW = MemArrBase sym ptrW (BaseBVType 8)
@@ -540,23 +544,24 @@ initMemTrace ::
   IO (MemTraceImpl sym ptrW)
 initMemTrace sym Addr32 = do
   arr <- ioFreshConstant sym "InitMem" knownRepr
-  return $ MemTraceImpl mempty arr
+  return $ MemTraceImpl mempty (MemTraceState arr)
 initMemTrace sym Addr64 = do
   arr <- ioFreshConstant sym "InitMem" knownRepr
-  return $ MemTraceImpl mempty arr
+  return $ MemTraceImpl mempty (MemTraceState arr)
 
-initMemTraceVar ::
+
+mkMemoryBinding ::
   forall sym ptrW.
-  IsSymInterface sym =>
-  sym ->
-  AddrWidthRepr ptrW ->
-  IO (MemTraceImpl sym ptrW, MemTraceVar sym ptrW)
-initMemTraceVar sym Addr32 = do
-  arr <- ioFreshConstant sym "InitMem" knownRepr
-  return $ (MemTraceImpl mempty arr, MemTraceVar arr)
-initMemTraceVar sym Addr64 = do
-  arr <- ioFreshConstant sym "InitMem" knownRepr
-  return $ (MemTraceImpl mempty arr, MemTraceVar arr)
+  MemTraceState sym ptrW ->
+  -- ^ initial memory state (appears in the the given expression when the binding is applied)
+  MemTraceState sym ptrW ->
+  -- ^ target memory state (to appear in the resulting expression when the binding is applied)
+  WEH.ExprBindings sym
+mkMemoryBinding memSrc memTgt =
+  let
+    MemTraceState memSrcArr = memSrc
+    MemTraceState memTgtArr = memTgt
+  in MapF.singleton memSrcArr memTgtArr
 
 equalPrefixOf :: forall a. Eq a => Seq a -> Seq a -> (Seq a, (Seq a, Seq a))
 equalPrefixOf s1 s2 = go s1 s2 Seq.empty
@@ -584,9 +589,9 @@ instance IntrinsicClass (ExprBuilder t st fs) "memory_trace" where
   -- TODO: cover other cases with a TypeError
   type Intrinsic (ExprBuilder t st fs) "memory_trace" (EmptyCtx ::> BVType ptrW) = MemTraceImpl (ExprBuilder t st fs) ptrW
   muxIntrinsic sym _ _ (Empty :> BVRepr _) p t f = do
-    s <- muxTraces p (memSeq t) (memSeq f)
-    arr <- baseTypeIte sym p (memArr t) (memArr f)
-    return $ MemTraceImpl s arr
+    memSeq' <- muxTraces p (memSeq t) (memSeq f)
+    memArr' <- baseTypeIte sym p (memArr $ memState t) (memArr $ memState f)
+    return $ MemTraceImpl memSeq' (MemTraceState memArr')
 
   muxIntrinsic _ _ _ _ _ _ _ = error "Unexpected operands in memory_trace mux"
 
@@ -868,7 +873,7 @@ doReadMem ::
   StateT (MemTraceImpl sym ptrW) IO (RegValue sym (MS.ToCrucibleType ty))
 doReadMem sym ptrW ptr memRepr = addrWidthClass ptrW $ do
   mem <- get
-  val <- liftIO $ readMemArr sym mem ptr memRepr
+  val <- liftIO $ readMemState sym (memState mem) ptr memRepr
   doMemOpInternal sym Read Unconditional ptrW ptr val memRepr
   pure val
 
@@ -883,7 +888,7 @@ doCondReadMem ::
   StateT (MemTraceImpl sym ptrW) IO (RegValue sym (MS.ToCrucibleType ty))
 doCondReadMem sym cond def ptrW ptr memRepr = addrWidthClass ptrW $ do
   mem <- get
-  val <- liftIO $ readMemArr sym mem ptr memRepr
+  val <- liftIO $ readMemState sym (memState mem) ptr memRepr
   doMemOpInternal sym Read (Conditional cond) ptrW ptr val memRepr
   liftIO $ iteDeep sym cond val def memRepr
 
@@ -991,16 +996,16 @@ chunkBV sym endianness w bv
         tl <- bvSelect sym (knownNat @0) sz' bv
         return (hd, tl)
 
--- | Read a packed value from the underlying array
-readMemArr :: forall sym ptrW ty.
+-- | Read a packed value from the underlying array (without adding to the read trace)
+readMemState :: forall sym ptrW ty.
   1 <= ptrW =>
   IsExprBuilder sym =>
   sym ->
-  MemTraceImpl sym ptrW ->
+  MemTraceState sym ptrW ->
   LLVMPtr sym ptrW ->
   MemRepr ty ->
   IO (RegValue sym (MS.ToCrucibleType ty))
-readMemArr sym mem ptr repr = go 0 repr
+readMemState sym mem ptr repr = go 0 repr
   where
   go :: Integer -> MemRepr ty' -> IO (RegValue sym (MS.ToCrucibleType ty'))
   go n (BVMemRepr byteWidth endianness) =
@@ -1029,25 +1034,42 @@ readMemArr sym mem ptr repr = go 0 repr
   go n (PackedVecMemRepr countRepr recRepr) = V.generateM (fromInteger (intValue countRepr)) $ \i ->
       go (n + memReprByteSize recRepr * fromIntegral i) recRepr
 
+-- | Compute the updated memory state resulting from writing a value to the given address, without
+-- accumulating any trace information.
+writeMemState ::
+  IsSymInterface sym =>
+  MemWidth ptrW =>
+  sym ->
+  RegValue sym BoolType ->
+  MemTraceState sym ptrW ->
+  LLVMPtr sym ptrW ->
+  MemRepr ty ->
+  RegValue sym (MS.ToCrucibleType ty) ->
+  IO (MemTraceState sym ptrW)
+writeMemState sym cond memSt ptr repr val = do
+  let mem = MemTraceImpl mempty memSt
+  MemTraceImpl _ memSt' <- execStateT (doMemOpInternal sym Write (Conditional cond) (addrWidthRepr mem) ptr val repr) mem
+  return memSt'
+
 -- | Write to the memory array and set the dirty bits on
 -- any written addresses
-writeMemArr :: forall sym ptrW w.
+writeMemBV :: forall sym ptrW w.
   1 <= ptrW =>
   IsExprBuilder sym =>
   sym ->
-  MemTraceImpl sym ptrW ->
+  MemTraceState sym ptrW ->
   LLVMPtr sym ptrW ->
   MemRepr (MT.BVType w) ->
   SymBV sym w ->
-  IO (MemTraceImpl sym ptrW)
-writeMemArr sym mem_init ptr repr val = go 0 repr val mem_init
+  IO (MemTraceState sym ptrW)
+writeMemBV sym mem_init ptr repr val = go 0 repr val mem_init
   where
   go ::
     Integer ->
     MemRepr (MT.BVType w') ->
     SymBV sym w' ->
-    MemTraceImpl sym ptrW ->
-    IO (MemTraceImpl sym ptrW)
+    MemTraceState sym ptrW ->
+    IO (MemTraceState sym ptrW)
   go n (BVMemRepr byteWidth endianness) bv mem =
     case isZeroOrGT1 (decNat byteWidth) of
       Left Refl -> do
@@ -1101,9 +1123,9 @@ doMemOpInternal sym dir cond ptrW = go where
         Write -> do
           LLVMPointer _ rawBv <- return regVal
           mem <- get
-          mem' <- liftIO $ writeMemArr sym mem ptr repr rawBv
-          arr <- liftIO $ ifCond sym cond (memArr mem') (memArr mem)
-          put $ mem { memArr = arr }
+          memSt' <- liftIO $ writeMemBV sym (memState mem) ptr repr rawBv
+          arr <- liftIO $ ifCond sym cond (memArr $ memSt') (memArr $ memState mem)
+          put $ mem { memState = MemTraceState arr }
     FloatMemRepr _infoRepr _endianness -> fail "reading floats not supported in doMemOpInternal"
     PackedVecMemRepr _countRepr recRepr -> addrWidthsArePositive ptrW $ do
       elemSize <- liftIO $ bvLit sym ptrWidthNatRepr (BV.mkBV ptrWidthNatRepr (memReprByteSize recRepr))
@@ -1256,10 +1278,10 @@ traceFootprint ::
   IsExprBuilder sym =>
   OrdF (SymExpr sym) =>
   sym ->
-  MemTraceSeq sym ptrW ->
+  MemTraceImpl sym ptrW ->
   IO (Set (MemFootprint sym ptrW))
 traceFootprint sym mem = do
-  footprints <- (fmap memOpFootprint) <$> flatMemOps sym mem
+  footprints <- (fmap memOpFootprint) <$> flatMemOps sym (memSeq mem)
   return $ foldl' (\a b -> Set.insert b a) mempty footprints
 
 llvmPtrEq ::
@@ -1280,6 +1302,50 @@ getCond ::
   Pred sym
 getCond sym Unconditional = truePred sym
 getCond _sym (Conditional p) = p
+
+
+-- | Memory states are equivalent everywhere but the given region.
+memEqOutsideRegion ::
+  forall sym ptrW.
+  IsExprBuilder sym =>
+  sym ->
+  SymNat sym ->
+  MemTraceState sym ptrW ->
+  MemTraceState sym ptrW ->
+  IO (Pred sym)
+memEqOutsideRegion sym region mem1 mem2 = do
+  iRegion <- natToInteger sym region
+  mem1Stack <- arrayLookup sym (memArr mem1) (Ctx.singleton iRegion)
+  mem2' <- arrayUpdate sym (memArr mem2) (Ctx.singleton iRegion) mem1Stack
+  isEq sym (memArr mem1) mem2'
+
+
+-- | Memory states are equivalent in the given region.
+memEqAtRegion ::
+  forall sym ptrW.
+  IsExprBuilder sym =>
+  sym ->
+  -- | stack memory region
+  SymNat sym ->
+  MemTraceState sym ptrW ->
+  MemTraceState sym ptrW ->
+  IO (Pred sym)
+memEqAtRegion sym stackRegion mem1 mem2 = do
+  iStackRegion <- natToInteger sym stackRegion
+  mem1Stack <- arrayLookup sym (memArr mem1) (Ctx.singleton iStackRegion)
+  mem2Stack <- arrayLookup sym (memArr mem2) (Ctx.singleton iStackRegion)
+  isEq sym mem1Stack mem2Stack
+
+
+-- | Memory states are exactly equivalent.
+memEqExact ::
+  forall sym ptrW.
+  IsExprBuilder sym =>
+  sym ->
+  MemTraceState sym ptrW ->
+  MemTraceState sym ptrW ->
+  IO (Pred sym)  
+memEqExact sym mem1 mem2 = isEq sym (memArr mem1) (memArr mem2)
 
 instance PEM.ExprMappable sym (MemOpCondition sym) where
   mapExpr _sym f = \case
@@ -1302,8 +1368,14 @@ instance PEM.ExprMappable sym (MemOp sym w) where
 instance PEM.ExprMappable sym (MemTraceImpl sym w) where
   mapExpr sym f mem = do
     memSeq' <- traverse (PEM.mapExpr sym f) $ memSeq mem
-    memArr' <- f $ memArr mem
-    return $ MemTraceImpl memSeq' memArr'
+    memState' <- PEM.mapExpr sym f $ memState mem
+    return $ MemTraceImpl memSeq' memState'
+
+instance PEM.ExprMappable sym (MemTraceState sym w) where
+  mapExpr _sym f memSt = do
+    memArr' <- f $ memArr memSt
+    return $ MemTraceState memArr'
+  foldExpr _sym f memSt b = f (memArr memSt) b
 
 instance PEM.ExprMappable sym (MemFootprint sym arch) where
   mapExpr sym f (MemFootprint ptr w dir cond end) = do

--- a/src/Pate/Memory/MemTrace.hs
+++ b/src/Pate/Memory/MemTrace.hs
@@ -519,8 +519,6 @@ type MemTraceArr sym ptrW = MemArrBase sym ptrW (BaseBVType 8)
 
 type MemArrBase sym ptrW tp = RegValue sym (SymbolicArrayType (EmptyCtx ::> BaseIntegerType) (BaseArrayType (EmptyCtx ::> BaseBVType ptrW) tp))
 
-type MemArrBaseType ptrW = BaseArrayType (EmptyCtx ::> BaseIntegerType) (BaseArrayType (EmptyCtx ::> BaseBVType ptrW) (BaseBVType 8))
-
 type MemTrace arch = IntrinsicType "memory_trace" (EmptyCtx ::> BVType (ArchAddrWidth arch))
 
 data MemTraceK
@@ -552,10 +550,10 @@ initMemTrace sym Addr64 = do
 
 mkMemoryBinding ::
   forall sym ptrW.
+  -- | initial memory state (appears in the the given expression when the binding is applied)
   MemTraceState sym ptrW ->
-  -- ^ initial memory state (appears in the the given expression when the binding is applied)
+  -- | target memory state (to appear in the resulting expression when the binding is applied)
   MemTraceState sym ptrW ->
-  -- ^ target memory state (to appear in the resulting expression when the binding is applied)
   WEH.ExprBindings sym
 mkMemoryBinding memSrc memTgt =
   let

--- a/src/Pate/Panic.hs
+++ b/src/Pate/Panic.hs
@@ -1,12 +1,11 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE PackageImports #-}
 
 module Pate.Panic (
   P.panic,
   PateComponent(..)
   ) where
 
-import qualified "panic" Panic as P
+import qualified Panic as P
 
 data PateComponent = Verifier
                    | Visualizer

--- a/src/Pate/Panic.hs
+++ b/src/Pate/Panic.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE PackageImports #-}
+
 module Pate.Panic (
   P.panic,
   PateComponent(..)
   ) where
 
-import qualified Panic as P
+import qualified "panic" Panic as P
 
 data PateComponent = Verifier
                    | Visualizer

--- a/src/Pate/Proof/Ground.hs
+++ b/src/Pate/Proof/Ground.hs
@@ -206,7 +206,7 @@ getPathCondition bundle slice dom fn = withSym $ \sym -> do
 
     getMemPath :: forall bin. PS.SimOutput sym arch bin -> EquivM sym arch (Const (W4.Pred sym) bin)
     getMemPath st = do
-      let mem = MT.memArr $ PS.simOutMem st
+      let mem = MT.memState $ PS.simOutMem st
       Const <$> (withGroundEvalFn fn $ \fn' -> getGenPathCondition sym fn' mem)
 
   let truePair = PPa.PatchPairC (W4.truePred sym) (W4.truePred sym)

--- a/src/Pate/Proof/Operations.hs
+++ b/src/Pate/Proof/Operations.hs
@@ -68,6 +68,7 @@ import qualified Pate.Equivalence.StatePred as PES
 import qualified Pate.Event as PE
 import qualified Pate.ExprMappable as PEM
 import qualified Pate.MemCell as PMC
+import qualified Pate.Memory.MemTrace as MT
 import           Pate.Monad
 import qualified Pate.Monad.Context as PMC
 import qualified Pate.Parallel as Par
@@ -124,8 +125,8 @@ simBundleToSlice bundle = withSym $ \sym -> do
       (Some (PMC.MemCell sym arch), W4.Pred sym) ->
       EquivM sym arch (MapF.Pair (PMC.MemCell sym arch) (PF.BlockSliceMemOp (PFI.ProofSym sym arch)))
     memCellToOp (PPa.PatchPair stO stP) (Some cell, cond) = withSym $ \sym -> do
-      valO <- liftIO $ PMC.readMemCell sym (PS.simMem stO) cell
-      valP <- liftIO $ PMC.readMemCell sym (PS.simMem stP) cell
+      valO <- liftIO $ PMC.readMemCell sym (MT.memState $ PS.simMem stO) cell
+      valP <- liftIO $ PMC.readMemCell sym (MT.memState $ PS.simMem stP) cell
       eqRel <- CMR.asks envBaseEquiv      
       isValidStack <- liftIO $ PE.applyMemEquivRelation (PE.eqRelStack eqRel) cell valO valP
       isValidGlobalMem <- liftIO $ PE.applyMemEquivRelation (PE.eqRelMem eqRel) cell valO valP

--- a/src/Pate/SimState.hs
+++ b/src/Pate/SimState.hs
@@ -51,15 +51,14 @@ module Pate.SimState
   -- variable binding
   , SimVars(..)
   , bindSpec
-  , flatVars
   -- assumption frames
   , AssumptionFrame(..)
   , isAssumedPred
   , exprBinding
+  , bindingToFrame
   , macawRegBinding
   , frameAssume
   , getAssumedPred
-  , rebindExpr
   , rebindWithFrame
   , rebindWithFrame'
   ) where
@@ -164,6 +163,15 @@ instance OrdF (W4.SymExpr sym) => Semigroup (AssumptionFrame sym) where
 instance OrdF (W4.SymExpr sym) => Monoid (AssumptionFrame sym) where
   mempty = AssumptionFrame mempty MapF.empty
 
+-- | Lift an expression binding environment into an assumption frame
+bindingToFrame ::
+  forall sym.
+  W4.IsSymExprBuilder sym =>
+  OrdF (W4.SymExpr sym) =>
+  ExprBindings sym ->
+  AssumptionFrame sym
+bindingToFrame binds = AssumptionFrame { asmPreds = mempty, asmBinds = MapF.map SetF.singleton binds }
+
 exprBinding ::
   forall sym tp.
   W4.IsSymExprBuilder sym =>
@@ -245,22 +253,6 @@ isAssumedPred ::
   Bool
 isAssumedPred frame asm = SetF.member asm (asmPreds frame)
 
-rebindExpr ::
-  forall sym t st fs ctx tp.
-  ( sym ~ W4B.ExprBuilder t st fs )
-  => sym
-  -> Ctx.Assignment (VarBinding sym) ctx
-  -> W4.SymExpr sym tp
-  -> IO (W4.SymExpr sym tp)
-rebindExpr sym bindings expr =
-  rebindWithFrame sym frame expr
-  where
-    frame = AssumptionFrame { asmPreds = mempty
-                            , asmBinds = TFC.foldrFC addSingletonBinding MapF.empty bindings
-                            }
-    addSingletonBinding varBinding =
-      MapF.insert (bindVar varBinding) (SetF.singleton (bindVal varBinding))
-
 -- | Explicitly rebind any known sub-expressions that are in the frame.
 rebindWithFrame ::
   forall sym t solver fs tp.
@@ -270,72 +262,18 @@ rebindWithFrame ::
   W4B.Expr t tp ->
   IO (W4B.Expr t tp)
 rebindWithFrame sym asm e = do
-  cache <- W4B.newIdxCache
+  cache <- freshVarBindCache
   rebindWithFrame' sym cache asm e
-
-newtype VarBinds sym = VarBinds (MapF.MapF (W4.SymExpr sym) (SetF (W4.BoundVar sym)))
-
-instance (OrdF (W4.BoundVar sym), OrdF (W4.SymExpr sym)) => Semigroup (VarBinds sym) where
-  (VarBinds v1) <> (VarBinds v2) = VarBinds $
-    MapF.mergeWithKey (\_ bvs1 bvs2 -> Just (bvs1 <> bvs2)) id id v1 v2
-
-instance (OrdF (W4.BoundVar sym), OrdF (W4.SymExpr sym)) => Monoid (VarBinds sym) where
-  mempty = VarBinds MapF.empty
-
-toAssignmentPair ::
-  [Pair f g] ->
-  Pair (Ctx.Assignment f) (Ctx.Assignment g)
-toAssignmentPair [] = Pair Ctx.empty Ctx.empty
-toAssignmentPair ((Pair a1 a2):xs) | Pair a1' a2' <- toAssignmentPair xs =
-  Pair (a1' Ctx.:> a1) (a2' Ctx.:> a2)
-
-flattenVarBinds ::
-  forall sym t solver fs.
-  sym ~ (W4B.ExprBuilder t solver fs) =>
-  VarBinds sym ->
-  [Pair (W4.BoundVar sym) (W4.SymExpr sym)]
-flattenVarBinds (VarBinds binds) = concat $ map go (MapF.toList binds)
-  where
-    go :: Pair (W4.SymExpr sym) (SetF (W4.BoundVar sym)) -> [Pair (W4.BoundVar sym) (W4.SymExpr sym)]
-    go (Pair e bvs) = map (\bv -> Pair bv e) $ SetF.toList bvs
-
-toBindings ::
-  forall sym t solver fs.
-  sym ~ (W4B.ExprBuilder t solver fs) =>
-  VarBinds sym ->
-  Pair (Ctx.Assignment (W4.BoundVar sym)) (Ctx.Assignment (W4.SymExpr sym))
-toBindings varBinds = toAssignmentPair (flattenVarBinds varBinds)
 
 rebindWithFrame' ::
   forall sym t solver fs tp.
   sym ~ (W4B.ExprBuilder t solver fs) =>
   sym ->
-  W4B.IdxCache t (Tagged (VarBinds sym) (W4B.Expr t)) ->
+  VarBindCache sym ->
   AssumptionFrame sym ->
   W4B.Expr t tp ->
   IO (W4B.Expr t tp)
-rebindWithFrame' sym cache asm e_outer = do
-  let
-    go :: forall tp'. W4B.Expr t tp' -> CMW.WriterT (VarBinds sym) IO (W4B.Expr t tp')
-    go e = idxCacheEvalWriter cache e $ case getUniqueBinding sym asm e of
-      Just e' -> do
-        bv <- IO.liftIO $ W4.freshBoundVar sym W4.emptySymbol (W4.exprType e')
-        CMW.tell $ VarBinds $ MapF.singleton e' (SetF.singleton bv)
-        return $ W4.varExpr sym bv
-      Nothing -> case e of
-        W4B.AppExpr a0 -> do
-          a0' <- W4B.traverseApp go (W4B.appExprApp a0)
-          if (W4B.appExprApp a0) == a0' then return e
-          else IO.liftIO $ W4B.sbMakeExpr sym a0'
-        W4B.NonceAppExpr a0 -> do
-          a0' <- TFC.traverseFC go (W4B.nonceExprApp a0)
-          if (W4B.nonceExprApp a0) == a0' then return e
-          else IO.liftIO $ W4B.sbNonceExpr sym a0'
-        _ -> return e
-  (e', binds) <- CMW.runWriterT (go e_outer)
-  Pair vars vals <- return $ toBindings binds
-  fn <- W4.definedFn sym W4.emptySymbol vars e' W4.AlwaysUnfold
-  W4.applySymFn sym fn vals >>= fixMux sym
+rebindWithFrame' sym cache asm = rewriteSubExprs' sym cache (getUniqueBinding sym asm)
 
 data SimSpec sym arch f = SimSpec
   {
@@ -398,35 +336,25 @@ simPair bundle = TF.fmapF simInBlock (simIn bundle)
 
 data SimVars sym arch bin = SimVars
   {
-    simVarMem :: MT.MemTraceVar sym (MM.ArchAddrWidth arch)
-  , simVarRegs :: MM.RegState (MM.ArchReg arch) (PSR.MacawRegVar sym)
+    simVarRegs :: MM.RegState (MM.ArchReg arch) (PSR.MacawRegVar sym)
   , simVarState :: SimState sym arch bin
   }
 
-flatVars ::
-  SimVars sym arch bin -> [Some (W4.SymExpr sym)]
-flatVars simVars =
-  let
-    regVarPairs =
-      MapF.toList $
-      MM.regStateMap $
-      (simVarRegs simVars)
-    regVars = concat $ map (\(MapF.Pair _ (PSR.MacawRegVar _ vars)) -> TFC.toListFC Some vars) regVarPairs
-    MT.MemTraceVar memVar = simVarMem simVars
-  in ((Some memVar):regVars)
 
-flatVarBinds ::
+mkVarBinds ::
   forall sym arch bin.
   HasCallStack =>
   MM.RegisterInfo (MM.ArchReg arch) =>
   W4.IsExprBuilder sym =>
+  OrdF (W4.SymExpr sym) =>
   sym ->
   SimVars sym arch bin ->
-  MT.MemTraceImpl sym (MM.ArchAddrWidth arch) ->
+  MT.MemTraceState sym (MM.ArchAddrWidth arch) ->
   MM.RegState (MM.ArchReg arch) (PSR.MacawRegEntry sym) ->
-  IO [Some (VarBinding sym)]
-flatVarBinds sym simVars mem regs = do
+  IO (ExprBindings sym)
+mkVarBinds sym simVars mem regs = do
   let
+    memVar = MT.memState $ simMem $ simVarState simVars
     regBinds =
       MapF.toList $
       MM.regStateMap $
@@ -437,17 +365,14 @@ flatVarBinds sym simVars mem regs = do
         CLM.LLVMPointer region off <- return $ PSR.macawRegValue val
         (Ctx.Empty Ctx.:> regVar Ctx.:> offVar) <- return $ vars
         iRegion <- W4.natToInteger sym region
-        return $ [Some (VarBinding regVar iRegion), Some (VarBinding offVar off)]
+        return $ [Pair regVar iRegion, Pair offVar off]
       CT.BoolRepr -> do
         Ctx.Empty Ctx.:> var <- return vars
-        return [Some (VarBinding var (PSR.macawRegValue val))]
+        return [Pair var (PSR.macawRegValue val)]
       CT.StructRepr Ctx.Empty -> return []
-      repr -> error ("flatVarBinds: unsupported type " ++ show repr)
+      repr -> error ("mkVarBinds: unsupported type " ++ show repr)
 
-  MT.MemTraceVar memVar <- return $ simVarMem simVars
-  let memBind = VarBinding memVar (MT.memArr mem)   
-  return $ ((Some memBind):regVarBinds)
-
+  mergeBindings sym (MT.mkMemoryBinding memVar mem) (MapF.fromList regVarBinds)
 
 bindSpec ::
   PEM.ExprMappable sym f =>
@@ -459,11 +384,13 @@ bindSpec ::
   SimSpec sym arch f ->
   IO (W4.Pred sym, f)
 bindSpec sym stO stP spec = do
-  flatO <- flatVarBinds sym (specVarsO spec) (simMem stO) (simRegs stO)
-  flatP <- flatVarBinds sym (specVarsP spec) (simMem stP) (simRegs stP)
-  Some flatCtx <- return $ Ctx.fromList (flatO ++ flatP)
-  body <- PEM.mapExpr sym (rebindExpr sym flatCtx) (specBody spec)
-  asm <- rebindExpr sym flatCtx (specAsm spec)
+  bindsO <- mkVarBinds sym (specVarsO spec) (MT.memState $ simMem stO) (simRegs stO)
+  bindsP <- mkVarBinds sym (specVarsP spec) (MT.memState $ simMem stP) (simRegs stP)
+  binds <- mergeBindings sym bindsO bindsP
+  cache <- freshVarBindCache
+  let doRewrite = applyExprBindings' sym cache binds
+  body <- PEM.mapExpr sym doRewrite (specBody spec)
+  asm <- doRewrite (specAsm spec)
   return $ (asm, body)
 
 ------------------------------------

--- a/src/Pate/SimState.hs
+++ b/src/Pate/SimState.hs
@@ -66,15 +66,11 @@ module Pate.SimState
 import           GHC.Stack ( HasCallStack )
 
 import           Control.Monad ( forM )
-import qualified Control.Monad.Writer as CMW
-import qualified Control.Monad.IO.Class as IO
 
-import           Data.Parameterized.Some
 import           Data.Parameterized.Classes
 import qualified Data.Parameterized.Context as Ctx
 import qualified Data.Parameterized.Map as MapF
 import           Data.Parameterized.Map ( Pair(..) )
-import qualified Data.Parameterized.TraversableFC as TFC
 import qualified Data.Parameterized.TraversableF as TF
 
 import qualified Data.Macaw.Symbolic as MS
@@ -95,7 +91,6 @@ import qualified Pate.PatchPair as PPa
 import qualified Pate.SimulatorRegisters as PSR
 import           What4.ExprHelpers
 import qualified Data.Parameterized.SetF as SetF
-import           Data.Parameterized.SetF (SetF)
 
 ------------------------------------
 -- Crucible inputs and outputs


### PR DESCRIPTION
The verifier now avoids directly using the underlying array
from the memory model

Fixes #136 
Fixes #175 