### PR TITLE
Clean up the external interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN ln -sf cabal.project.dist cabal.project
 RUN cabal configure pkg:pate -w ghc-8.10.4 && \
   cabal build pkg:pate -j5
 
-RUN cp $(cabal exec -- which pate-exec) /usr/local/bin/pate
+RUN cp $(cabal exec -- which pate) /usr/local/bin/pate
 
 FROM ubuntu:20.04
 RUN apt update && apt install -y zlibc zlib1g libgmp10 libantlr3c-3.4-0 locales && locale-gen en_US.UTF-8

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -2,7 +2,7 @@ CC=powerpc64-linux-gnu-gcc
 
 .PHONY: demo1
 demo1: demo1/demo1.original.i demo1/demo1.patched.i
-	cabal v2-run exe:pate-exec -- --arch PPC \
+	cabal v2-run exe:pate -- --arch PPC \
                                 --original demo1/demo1.original.exe \
                                 --patched demo1/demo1.patched.exe \
                                 --interactive \
@@ -11,7 +11,7 @@ demo1: demo1/demo1.original.i demo1/demo1.patched.i
 
 .PHONY: demo2
 demo2: demo2/demo2.original.i demo2/demo2.patched.i
-	cabal v2-run exe:pate-exec -- --arch PPC \
+	cabal v2-run exe:pate -- --arch PPC \
                                 --original demo2/demo2.original.exe \
                                 --patched demo2/demo2.patched.exe \
                                 --interactive \
@@ -20,7 +20,7 @@ demo2: demo2/demo2.original.i demo2/demo2.patched.i
 
 .PHONY: demo3
 demo3: demo3/demo3.original.i demo3/demo3.patched.i
-	cabal v2-run exe:pate-exec -- --arch PPC \
+	cabal v2-run exe:pate -- --arch PPC \
                                 --original demo3/demo3.original.exe \
                                 --patched demo3/demo3.patched.exe \
                                 --interactive \
@@ -29,7 +29,7 @@ demo3: demo3/demo3.original.i demo3/demo3.patched.i
 
 .PHONY: demo4
 demo4: demo4/demo4.original.i demo4/demo4.patched.i
-	cabal v2-run exe:pate-exec -- --arch PPC \
+	cabal v2-run exe:pate -- --arch PPC \
                                 --original demo4/demo4.original.exe \
                                 --patched demo4/demo4.patched.exe \
                                 --interactive \
@@ -38,7 +38,7 @@ demo4: demo4/demo4.original.i demo4/demo4.patched.i
 
 .PHONY: inlining
 inlining: ../tests/ppc/test-direct-calls.original.i ../tests/ppc/test-direct-calls.patched.i
-	cabal v2-run exe:pate-exec -- --arch PPC \
+	cabal v2-run exe:pate -- --arch PPC \
                                 --original ../tests/ppc/test-direct-calls.original.exe \
                                 --patched ../tests/ppc/test-direct-calls.patched.exe \
                                 --interactive \
@@ -46,19 +46,19 @@ inlining: ../tests/ppc/test-direct-calls.original.i ../tests/ppc/test-direct-cal
                                 --patched-source ../tests/ppc/test-direct-calls.patched.i
 .PHONY: challenge02
 challenge02: challenge02/challenge-02.original.exe challenge02/challenge-02.patched.exe
-	cabal v2-run exe:pate-exec -- \
+	cabal v2-run exe:pate -- \
                                 --original challenge02/challenge-02.original.exe \
                                 --patched challenge02/challenge-02.patched.exe
 
 .PHONY: challenge02-self
 challenge02-self: challenge02/challenge-02.original.exe challenge02/challenge-02.original.exe
-	cabal v2-run exe:pate-exec -- \
+	cabal v2-run exe:pate -- \
                                 --original challenge02/challenge-02.original.exe \
                                 --patched challenge02/challenge-02.original.exe
 
 .PHONY: challenge03
 challenge03: challenge03/challenge03.original.exe challenge03/challenge03.patched.exe
-	cabal v2-run exe:pate-exec -- \
+	cabal v2-run exe:pate -- \
 		                       --original challenge03/challenge03.original.exe \
 							   --patched challenge03/challenge03.patched.exe \
 							   --blockinfo challenge03/challenge03.info \
@@ -66,7 +66,7 @@ challenge03: challenge03/challenge03.original.exe challenge03/challenge03.patche
 
 .PHONY: abort
 abort: abort/test-abort.original.exe abort/test-abort.patched.exe abort/test-abort.hints.csv
-	cabal v2-run exe:pate-exec -- \
+	cabal v2-run exe:pate -- \
 		                       --original abort/test-abort.original.exe \
 	                           --patched abort/test-abort.patched.exe \
 							   --original-csv-function-hints abort/test-abort.hints.csv

--- a/demos/demo1/demo1.sh
+++ b/demos/demo1/demo1.sh
@@ -5,4 +5,4 @@ echo "Patched:"
 cat demo1.patched.c
 
 set -x
-cabal v2-run pate-exec -- --arch PPC -o demo1.original.exe -p demo1.patched.exe
+cabal v2-run exe:pate -- --arch PPC -o demo1.original.exe -p demo1.patched.exe

--- a/demos/demo2/demo2.sh
+++ b/demos/demo2/demo2.sh
@@ -5,4 +5,4 @@ echo "Patched:"
 cat demo2.patched.c
 
 set -x
-cabal v2-run pate-exec -- --arch PPC -o demo2.original.exe -p demo2.patched.exe
+cabal v2-run exe:pate -- --arch PPC -o demo2.original.exe -p demo2.patched.exe

--- a/demos/demo3/demo3.sh
+++ b/demos/demo3/demo3.sh
@@ -5,4 +5,4 @@ echo "Patched:"
 cat demo3.patched.c
 
 set -x
-cabal v2-run pate-exec -- --arch PPC -o demo3.original.exe -p demo3.patched.exe
+cabal v2-run exe:pate -- --arch PPC -o demo3.original.exe -p demo3.patched.exe

--- a/demos/demo4/demo4.sh
+++ b/demos/demo4/demo4.sh
@@ -5,4 +5,4 @@ echo "Patched:"
 cat demo4.patched.c
 
 set -x
-cabal v2-run pate-exec -- --arch PPC -o demo4.original.exe -p demo4.patched.exe
+cabal v2-run exe:pate -- --arch PPC -o demo4.original.exe -p demo4.patched.exe

--- a/pate.cabal
+++ b/pate.cabal
@@ -235,7 +235,7 @@ common shared-exec
                  pate 
 
 
-executable pate-exec
+executable pate
   import:              shared-exec, shared
   main-is:             Main.hs
   other-modules:       Pate.PPC,

--- a/src/Pate/Interactive/Render/Console.hs
+++ b/src/Pate/Interactive/Render/Console.hs
@@ -6,6 +6,7 @@ module Pate.Interactive.Render.Console (
 import           Control.Lens ( (^.) )
 import           Control.Monad ( void )
 import           Control.Monad.IO.Class ( liftIO )
+import qualified Data.Foldable as F
 import qualified Data.IORef as IOR
 import           Data.Parameterized.Some ( Some(..) )
 import           Graphics.UI.Threepenny ( (#), (#+), (#.) )
@@ -128,4 +129,4 @@ renderConsole :: (PA.ValidArch arch)
               -> TP.UI TP.Element
 renderConsole r detailDiv = do
   state <- liftIO $ IOR.readIORef (IS.stateRef r)
-  TP.ul #+ (map (\evt -> TP.li #+ [renderEvent state detailDiv evt]) (reverse (state ^. IS.recentEvents)))
+  TP.ul #+ (map (\evt -> TP.li #+ [renderEvent state detailDiv evt]) (reverse (F.toList (state ^. IS.recentEvents))))


### PR DESCRIPTION
* Rename `pate-exec` to just `pate`
* Unify the options to log to a file

This substantially simplifies the logging logic, which previously tangled up a lot of UI logic with file logging logic. Later, JSON reporting logic was threaded through, too. Now, we use the lumberjack `Semigroup` instance for `LogAction` to provide three separate loggers (and combine them for easy use).

There is a new default for console output: we never generate console output. If no log file is specified, detailed logs are simply not generated. The console output is removed, as it was impossible to navigate anyway.