### PR TITLE
Swap out the `MVar`-based futures implementation for

### DIFF
--- a/src/Pate/Equivalence/MemPred.hs
+++ b/src/Pate/Equivalence/MemPred.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 module Pate.Equivalence.MemPred (
     MemPred(..)

--- a/src/Pate/Monad.hs
+++ b/src/Pate/Monad.hs
@@ -621,6 +621,7 @@ instance Par.IsFuture (EquivM_ sym arch) Par.Future where
   promise m = IO.withRunInIO $ \runInIO -> Par.promise (runInIO m)
   joinFuture future = withValid $ catchInIO $ Par.joinFuture future
   forFuture future f = IO.withRunInIO $ \runInIO -> Par.forFuture future (runInIO . f)
+  immediate a = liftIO (Par.immediate a)
 
 withGroundEvalFn ::
   SymGroundEvalFn sym ->


### PR DESCRIPTION
one based on the `async` library.

This basically seems to work, but does not fix the nondeterministic
test suite failures as I hoped it would. Not clear if it is worth
doing on it's own.