### PR TITLE
restructure EquivTriple to push SimSpec inside

### DIFF
--- a/src/Pate/Proof.hs
+++ b/src/Pate/Proof.hs
@@ -108,9 +108,9 @@ import qualified What4.Interface as W4
 -- proof objects
 
 
--- | An triple representing the equivalence conditions for a block pair. Abstracted
--- over the initial machine state. This is analogous to a 'ProofExpr' of type
--- 'ProofTriple', but contains the 'PE.StatePred' type that the verifier uses.
+-- | An triple representing the equivalence conditions for a block pair.
+-- This is analogous to a 'ProofExpr' of type
+-- 'ProofTriple', but contains the 'PE.StatePredSpec' type that the verifier uses.
 -- This redundancy can potentially be eliminated at some point.
 data EquivTriple sym arch where
   EquivTriple ::

--- a/src/Pate/Proof.hs
+++ b/src/Pate/Proof.hs
@@ -32,8 +32,7 @@ Representation and presentation of the equivalence proofs
 {-# LANGUAGE ImplicitParams #-}
 
 module Pate.Proof
-  ( EquivTripleBody(..)
-  , EquivTriple
+  ( EquivTriple(..)
   , VerificationStatus(..)
   , ProofApp(..)
   , MemoryDomain(..)
@@ -109,32 +108,23 @@ import qualified What4.Interface as W4
 -- proof objects
 
 
--- | The body of an 'EquivTriple'.
-data EquivTripleBody sym arch where
-  EquivTripleBody ::
-    {
-      eqPair :: PPa.BlockPair arch
-      -- ^ the entry points that yield equivalent states on the post-domain
-      -- after execution, assuming initially equivalent states on the pre-domain
-    , eqPreDomain :: PES.StatePred sym arch
-      -- ^ the pre-domain: the state that was assumed initially equivalent
-      -- closed over the bound variables representing the initial state
-    , eqPostDomain :: PE.StatePredSpec sym arch
-      -- ^ the post-domain: the state that was proven equivalent after execution
-      -- abstracted over the bound variables representing the final state
-    } -> EquivTripleBody sym arch
-
-instance PEM.ExprMappable sym (EquivTripleBody sym arch) where
-  mapExpr sym f triple = do
-    eqPreDomain' <- PEM.mapExpr sym f (eqPreDomain triple)
-    eqPostDomain' <- PEM.mapExpr sym f (eqPostDomain triple)
-    return $ EquivTripleBody (eqPair triple) eqPreDomain' eqPostDomain'
-
 -- | An triple representing the equivalence conditions for a block pair. Abstracted
 -- over the initial machine state. This is analogous to a 'ProofExpr' of type
 -- 'ProofTriple', but contains the 'PE.StatePred' type that the verifier uses.
 -- This redundancy can potentially be eliminated at some point.
-type EquivTriple sym arch = PS.SimSpec sym arch (EquivTripleBody sym arch)
+data EquivTriple sym arch where
+  EquivTriple ::
+    {
+      eqPair :: PPa.BlockPair arch
+      -- ^ the entry points that yield equivalent states on the post-domain
+      -- after execution, assuming initially equivalent states on the pre-domain
+    , eqPreDomain :: PE.StatePredSpec sym arch
+      -- ^ the pre-domain: the state that was assumed initially equivalent
+      -- abstracted over the bound variables representing the initial state
+    , eqPostDomain :: PE.StatePredSpec sym arch
+      -- ^ the post-domain: the state that was proven equivalent after execution
+      -- abstracted over the bound variables representing the final state
+    } -> EquivTriple sym arch
 
 data ProofNodeType where
     ProofTripleType :: ProofNodeType

--- a/src/Pate/Verification.hs
+++ b/src/Pate/Verification.hs
@@ -456,11 +456,10 @@ checkEquivalence triple = startTimer $ withSym $ \sym -> do
         CMR.local (\env -> env { envConfig = (envConfig env){PC.cfgComputeEquivalenceFrames = True} }) $
           doProof
 
-  void $ withSimSpec pPair triple $ \stO stP tripleBody -> do
+  void $ withSimSpec pPair (PF.eqPreDomain triple) $ \stO stP precond -> do
     let
       inO = SimInput stO (PPa.pOriginal pPair)
       inP = SimInput stP (PPa.pPatched pPair)
-      precond = PF.eqPreDomain tripleBody
     (_, genPrecond) <- liftIO $ bindSpec sym stO stP genPrecondSpec
     preImpliesGen <- liftIO $ impliesPrecondition sym stackRegion inO inP eqRel precond genPrecond
     -- prove that the generated precondition is implied by the given precondition
@@ -486,10 +485,8 @@ checkEquivalence triple = startTimer $ withSym $ \sym -> do
       _ -> return PEq.ConditionallyEquivalent
     _ -> return PEq.Inequivalent
   where
-    -- TODO: this breaks the model somewhat, since we're relying on these not containing
-    -- the bound terms
-    pPair = PF.eqPair $ specBody triple
-    postcondSpec = PF.eqPostDomain $ specBody triple
+    pPair = PF.eqPair triple
+    postcondSpec = PF.eqPostDomain triple
 
 --------------------------------------------------------
 -- Simulation
@@ -579,7 +576,7 @@ catchSimBundle pPair postcondSpec f = do
             traceBlockPair pPair ("Caught error: " ++ show err)
             errorResult
           Right r -> return r
-      let triple = fmap (\precond -> PF.EquivTripleBody pPair precond postcondSpec) precondSpec
+      let triple = PF.EquivTriple pPair precondSpec postcondSpec
       future <- PFO.asFutureNonceApp prf
       modifyBlockCache envProofCache pPair (++) [(triple, future)]
       return $ (precondSpec, prf)
@@ -594,11 +591,11 @@ catchSimBundle pPair postcondSpec f = do
       EquivM sym arch (Maybe ret)
     getCached (triple, futureProof) = do
       traceBlockPair pPair "Checking for cached result"
-      impliesPostcond pPair (PF.eqPostDomain $ specBody triple) postcondSpec >>= \case
+      impliesPostcond pPair (PF.eqPostDomain triple) postcondSpec >>= \case
         True -> do
           traceBlockPair pPair "Cache hit"
           prf' <- PFO.wrapFutureNonceApp futureProof
-          return $ Just (fmap PF.eqPreDomain triple, prf')
+          return $ Just (PF.eqPreDomain triple, prf')
         False -> do
           traceBlockPair pPair "Cache miss"
           return Nothing
@@ -1185,20 +1182,17 @@ topLevelTriple ::
 topLevelTriple fnPair =
   let pPair = TF.fmapF PB.functionEntryToConcreteBlock fnPair in
   withPair pPair $
-  withFreshVars pPair $ \stO stP ->
   withSym $ \sym -> do
     regDomain <- PVD.allRegistersDomain
     postcond <- topLevelPostDomain pPair
-    let
-      precond = PES.StatePred
-        { PES.predRegs = regDomain
-        , PES.predStack = PEM.memPredTrue sym
-        , PES.predMem = PEM.memPredTrue sym
-        }
-    let triple = PF.EquivTripleBody pPair precond postcond
-    asm_frame <- PVV.validInitState (Just pPair) stO stP
-    asm <- liftIO $ getAssumedPred sym asm_frame
-    return (asm, triple)
+    precond <- withFreshVars pPair $ \stO stP -> do
+      withAssumptionFrame (PVV.validInitState (Just pPair) stO stP) $
+        return $ PES.StatePred
+          { PES.predRegs = regDomain
+          , PES.predStack = PEM.memPredTrue sym
+          , PES.predMem = PEM.memPredTrue sym
+          }
+    return $ PF.EquivTriple pPair precond postcond
 
 --------------------------------------------------------
 -- Totality check - ensure that the verified exit pairs cover all possible


### PR DESCRIPTION
free variables of the post-domain should be disjoint
from the pre-domain, so this more accurately represents
the variable scope

fixes #198 