### PR TITLE
Reduce memory initialization time

### DIFF
--- a/src/Pate/Memory/MemTrace.hs
+++ b/src/Pate/Memory/MemTrace.hs
@@ -79,7 +79,7 @@ import Data.Macaw.CFG.AssignRhs (ArchAddrWidth, MemRepr(..))
 import Data.Macaw.Memory (AddrWidthRepr(..), Endianness(..), MemWidth, addrWidthClass, addrWidthRepr, addrWidthNatRepr)
 import Data.Macaw.Symbolic.Backend (MacawEvalStmtFunc, MacawArchEvalFn(..))
 import Data.Macaw.Symbolic ( MacawStmtExtension(..), MacawExprExtension(..), MacawExt
-                           , GlobalMap, MacawSimulatorState(..)
+                           , GlobalMap
                            , IsMemoryModel(..)
                            , SymArchConstraints
                            , evalMacawExprExtension
@@ -436,11 +436,11 @@ mkUndefinedPtrOps sym = do
 -- performing them.
 macawTraceExtensions ::
   (IsSymInterface sym, SymArchConstraints arch, sym ~ ExprBuilder t st fs) =>
-  MacawArchEvalFn sym (MemTrace arch) arch ->
+  MacawArchEvalFn p sym (MemTrace arch) arch ->
   GlobalVar (MemTrace arch) ->
   GlobalMap sym (MemTrace arch) (ArchAddrWidth arch) ->
   UndefinedPtrOps sym ->
-  ExtensionImpl (MacawSimulatorState sym) sym (MacawExt arch)
+  ExtensionImpl p sym (MacawExt arch)
 macawTraceExtensions archStmtFn mvar globs undefptr =
   ExtensionImpl
     { extensionEval = \bak iTypes logFn cst g -> evalMacawExprExtensionTrace undefptr bak iTypes logFn cst g
@@ -600,15 +600,15 @@ memTraceIntrinsicTypes = id
   . MapF.insert (knownSymbol :: SymbolRepr "LLVM_pointer") IntrinsicMuxFn
   $ MapF.empty
 
-type MacawTraceEvalStmtFunc sym arch = MacawEvalStmtFunc (MacawStmtExtension arch) (MacawSimulatorState sym) sym (MacawExt arch)
+type MacawTraceEvalStmtFunc p sym arch = MacawEvalStmtFunc (MacawStmtExtension arch) p sym (MacawExt arch)
 
 execMacawStmtExtension ::
-  forall sym arch t st fs. (IsSymInterface sym, SymArchConstraints arch, sym ~ ExprBuilder t st fs) =>
-  MacawArchEvalFn sym (MemTrace arch) arch ->
+  forall p sym arch t st fs. (IsSymInterface sym, SymArchConstraints arch, sym ~ ExprBuilder t st fs) =>
+  MacawArchEvalFn p sym (MemTrace arch) arch ->
   UndefinedPtrOps sym ->
   GlobalVar (MemTrace arch) ->
   GlobalMap sym (MemTrace arch) (ArchAddrWidth arch) ->
-  MacawTraceEvalStmtFunc sym arch
+  MacawTraceEvalStmtFunc p sym arch
 execMacawStmtExtension (MacawArchEvalFn archStmtFn) mkundef mvar globs stmt
   = case stmt of
     MacawReadMem addrWidth memRepr addr

--- a/src/Pate/Verification/DemandDiscovery.hs
+++ b/src/Pate/Verification/DemandDiscovery.hs
@@ -256,7 +256,7 @@ decodeAndCallFunction pfm archVals loadedBinary crucState regsRepr bvAddr =
 -- incremental code discovery (only binding function handles and doing code
 -- discovery on demand).
 lookupFunction
-  :: forall sym arch bin mem binFmt solver scope st fs
+  :: forall p sym arch bin mem binFmt solver scope st fs
    . ( PA.ValidArch arch
      , LCB.IsSymInterface sym
      , PBi.KnownBinary bin
@@ -271,7 +271,7 @@ lookupFunction
   -> PMC.ParsedFunctionMap arch bin
   -> DMS.GenArchVals mem arch
   -> MBL.LoadedBinary arch binFmt
-  -> DMS.LookupFunctionHandle sym arch
+  -> DMS.LookupFunctionHandle p sym arch
 lookupFunction bak argMap overrides symtab pfm archVals loadedBinary = DMS.LookupFunctionHandle $ \crucState _mem0 regs -> do
   let regsRepr = LCT.StructRepr (DMS.crucArchRegTypes (DMS.archFunctions archVals))
   let regsEntry = LCS.RegEntry regsRepr regs

--- a/src/Pate/Verification/InlineCallee.hs
+++ b/src/Pate/Verification/InlineCallee.hs
@@ -231,12 +231,13 @@ populateRelocation bak _reloc =
 -- are different. The best approach is probably to compute a sound
 -- over-approximation of the available memory.
 allocateInitialState
-  :: forall arch sym bak w
+  :: forall arch sym bak w t st fs
    . ( LCB.IsSymBackend sym bak
      , w ~ DMC.ArchAddrWidth arch
      , PA.ValidArch arch
      , LCLM.HasPtrWidth w
      , LCLM.HasLLVMAnn sym
+     , sym ~ WE.ExprBuilder t st fs
      , ?memOpts :: LCLM.MemOptions
      )
   => bak


### PR DESCRIPTION
The real change is in macaw, which required a tiny API update. Note that this primarily affects the inline callee functionality