### PR TITLE
Explicitly check for the case when no valid block exits are found

### DIFF
--- a/demos/Makefile
+++ b/demos/Makefile
@@ -63,6 +63,8 @@ challenge03: challenge03-variant/challenge03.orig.exe challenge03-variant/challe
 							   --patched $(word 2,$^) \
 							   --blockinfo $(word 3,$^) \
 							   --log-file challenge03.out \
+							   --verbosity Debug \
+							   --noproofs \
 							   --ignoremain
 
 .PHONY: abort

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -57,11 +57,12 @@ challenge02-self: challenge02/challenge-02.original.exe challenge02/challenge-02
                                 --patched challenge02/challenge-02.original.exe
 
 .PHONY: challenge03
-challenge03: challenge03/challenge03.original.exe challenge03/challenge03.patched.exe
+challenge03: challenge03-variant/challenge03.orig.exe challenge03-variant/challenge03.patched.exe challenge03-variant/challenge03.info
 	cabal v2-run exe:pate -- \
-		                       --original challenge03/challenge03.original.exe \
-							   --patched challenge03/challenge03.patched.exe \
-							   --blockinfo challenge03/challenge03.info \
+		                       --original $(word 1,$^) \
+							   --patched $(word 2,$^) \
+							   --blockinfo $(word 3,$^) \
+							   --log-file challenge03.out \
 							   --ignoremain
 
 .PHONY: abort

--- a/src/Pate/Proof/Instances.hs
+++ b/src/Pate/Proof/Instances.hs
@@ -58,7 +58,6 @@ import           Data.Proxy
 import           GHC.Natural
 import           Numeric
 
-import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.BitVector.Sized as BVS
 import           Data.Parameterized.Classes

--- a/src/Pate/Verification.hs
+++ b/src/Pate/Verification.hs
@@ -966,7 +966,8 @@ proveLocalPostcondition bundle postcondSpec = withSym $ \sym -> do
                           traceBundle bundle "proveLocalPostcondition->getInequivalenceResult"
                           ir <- PFC.getInequivalenceResult PEE.InvalidPostState (PVD.universalDomain sym) postDomain' blockSlice fn
                           traceBundle bundle "proveLocalPostcondition->getEquivalenceResult"
-                          cr <- getCondEquivalenceResult bundle cond'' fn
+                          cr' <- getCondEquivalenceResult bundle cond'' fn
+                          cr <- applyCurrentFrame cr'
                           traceBundle bundle ("conditionalEquivalenceResult: " ++ show (W4.printSymExpr (PF.condEqPred cr)))
                           return $ PF.VerificationFail ir cr
                         W4R.Unsat _ -> return $ status


### PR DESCRIPTION
Fixes issue #216 by adding an explicit check for when no matching block exit conditions are found