### PR TITLE
remove largely unused 'EquivRelation'

### DIFF
--- a/src/Pate/Discovery.hs
+++ b/src/Pate/Discovery.hs
@@ -191,9 +191,9 @@ exactEquivalence ::
   PSS.SimInput sym arch PB.Patched ->
   EquivM sym arch (WI.Pred sym)
 exactEquivalence inO inP = withSym $ \sym -> do
-  eqRel <- CMR.asks envBaseEquiv
+  eqCtx <- equivalenceContext
   regsEqs <- liftIO $ PRt.zipWithRegStatesM (PSS.simInRegs inO) (PSS.simInRegs inP) $ \r v1 v2 ->
-    Const <$> PEq.applyRegEquivRelation (PEq.eqRelRegs eqRel) r v1 v2
+    Const <$> PEq.applyRegEquiv sym eqCtx r v1 v2
 
   regsEq <- liftIO $ WEH.allPreds sym (map snd $ PRt.assocs regsEqs)
   heuristicTimeout <- CMR.asks (PC.cfgHeuristicTimeout . envConfig)

--- a/src/Pate/Discovery.hs
+++ b/src/Pate/Discovery.hs
@@ -193,7 +193,7 @@ exactEquivalence ::
 exactEquivalence inO inP = withSym $ \sym -> do
   eqCtx <- equivalenceContext
   regsEqs <- liftIO $ PRt.zipWithRegStatesM (PSS.simInRegs inO) (PSS.simInRegs inP) $ \r v1 v2 ->
-    Const <$> PEq.applyRegEquiv sym eqCtx r v1 v2
+    Const <$> PEq.registerValuesEqual sym eqCtx r v1 v2
 
   regsEq <- liftIO $ WEH.allPreds sym (map snd $ PRt.assocs regsEqs)
   heuristicTimeout <- CMR.asks (PC.cfgHeuristicTimeout . envConfig)

--- a/src/Pate/Monad.hs
+++ b/src/Pate/Monad.hs
@@ -74,6 +74,8 @@ module Pate.Monad
   , lookupBlockCache
   , modifyBlockCache
   , freshBlockCache
+  -- equivalence
+  , equivalenceContext
   )
   where
 
@@ -126,6 +128,7 @@ import qualified Pate.Arch as PA
 import qualified Pate.Binary as PBi
 import qualified Pate.Block as PB
 import qualified Pate.Config as PC
+import qualified Pate.Equivalence as PEq
 import qualified Pate.Equivalence.Error as PEE
 import qualified Pate.Event as PE
 import qualified Pate.ExprMappable as PEM
@@ -756,3 +759,12 @@ instance MF.MonadFail (EquivM_ sym arch) where
 
 manifestError :: MonadError e m => m a -> m (Either e a)
 manifestError act = catchError (Right <$> act) (pure . Left)
+
+----------------------------------------
+
+equivalenceContext ::
+  EquivM sym arch (PEq.EquivContext sym arch)
+equivalenceContext = do
+  PA.SomeValidArch d <- CMR.asks envValidArch
+  stackRegion <- CMR.asks (PMC.stackRegion . PME.envCtx)
+  return $ PEq.EquivContext (PA.validArchDedicatedRegisters d) stackRegion

--- a/src/Pate/Monad/Environment.hs
+++ b/src/Pate/Monad/Environment.hs
@@ -37,7 +37,6 @@ import qualified Pate.Arch as PA
 import qualified Pate.Binary as PBi
 import qualified Pate.Block as PB
 import qualified Pate.Config as PC
-import           Pate.Equivalence
 import qualified Pate.Equivalence.Statistics as PES
 import qualified Pate.Event as PE
 import qualified Pate.Memory.MemTrace as MT
@@ -72,7 +71,6 @@ data EquivEnv sym arch where
     , envLogger :: LJ.LogAction IO (PE.Event arch)
     , envConfig :: PC.VerificationConfig
     , envFailureMode :: VerificationFailureMode
-    , envBaseEquiv :: EquivRelation sym arch
     , envGoalTriples :: [PPE.EquivTriple sym arch]
     -- ^ input equivalence problems to solve
     , envValidSym :: PSo.Sym sym

--- a/src/Pate/Proof/Operations.hs
+++ b/src/Pate/Proof/Operations.hs
@@ -106,7 +106,7 @@ simBundleToSlice bundle = withSym $ \sym -> do
       EquivM sym arch (PF.BlockSliceRegOp sym tp)
     getReg reg valO valP = withSym $ \sym -> do
       eqCtx <- equivalenceContext
-      isEquiv <- liftIO $ PE.applyRegEquiv sym eqCtx reg valO valP
+      isEquiv <- liftIO $ PE.registerValuesEqual sym eqCtx reg valO valP
       return $ PF.BlockSliceRegOp
         (PPa.PatchPairC valO valP)
         (PSR.macawRegRepr valO)

--- a/src/Pate/Proof/Operations.hs
+++ b/src/Pate/Proof/Operations.hs
@@ -104,9 +104,9 @@ simBundleToSlice bundle = withSym $ \sym -> do
       PSR.MacawRegEntry sym tp ->
       PSR.MacawRegEntry sym tp ->
       EquivM sym arch (PF.BlockSliceRegOp sym tp)
-    getReg reg valO valP = do
-      eqRel <- CMR.asks envBaseEquiv
-      isEquiv <- liftIO $ PE.applyRegEquivRelation (PE.eqRelRegs eqRel) reg valO valP
+    getReg reg valO valP = withSym $ \sym -> do
+      eqCtx <- equivalenceContext
+      isEquiv <- liftIO $ PE.applyRegEquiv sym eqCtx reg valO valP
       return $ PF.BlockSliceRegOp
         (PPa.PatchPairC valO valP)
         (PSR.macawRegRepr valO)
@@ -119,10 +119,7 @@ simBundleToSlice bundle = withSym $ \sym -> do
     memCellToOp (PPa.PatchPair stO stP) (Some cell, cond) = withSym $ \sym -> do
       valO <- liftIO $ PMC.readMemCell sym (MT.memState $ PS.simMem stO) cell
       valP <- liftIO $ PMC.readMemCell sym (MT.memState $ PS.simMem stP) cell
-      eqRel <- CMR.asks envBaseEquiv      
-      isValidStack <- liftIO $ PE.applyMemEquivRelation (PE.eqRelStack eqRel) cell valO valP
-      isValidGlobalMem <- liftIO $ PE.applyMemEquivRelation (PE.eqRelMem eqRel) cell valO valP
-      isEquiv <- liftIO $ W4.andPred sym isValidStack isValidGlobalMem
+      isEquiv <- liftIO $ MT.llvmPtrEq sym valO valP
       return $ MapF.Pair cell $ PF.BlockSliceMemOp
         { PF.slMemOpValues = PPa.PatchPairC valO valP
         , PF.slMemOpEquiv = isEquiv

--- a/src/Pate/Verification.hs
+++ b/src/Pate/Verification.hs
@@ -190,7 +190,7 @@ doVerifyPairs ::
   N.NonceGenerator IO scope ->
   sym ->
   CME.ExceptT (PEE.EquivalenceError arch) IO PEq.EquivalenceStatus
-doVerifyPairs validArch@(PA.SomeValidArch (PA.validArchDedicatedRegisters -> hdr)) logAction elf elf' vcfg pd gen sym = do
+doVerifyPairs validArch logAction elf elf' vcfg pd gen sym = do
   startTime <- liftIO TM.getCurrentTime
   (traceVals, llvmVals) <- case ( MS.genArchVals (Proxy @MT.MemTraceK) (Proxy @arch) Nothing
                                 , MS.genArchVals (Proxy @MS.LLVMMemory) (Proxy @arch) Nothing) of

--- a/src/Pate/Verification/Domain.hs
+++ b/src/Pate/Verification/Domain.hs
@@ -260,7 +260,6 @@ guessEquivalenceDomain bundle goal postcond = startTimer $ withSym $ \sym -> do
   PA.SomeValidArch (PA.validArchDedicatedRegisters -> hdr) <- CMR.asks envValidArch
   traceBundle bundle "Entering guessEquivalenceDomain"
   WEH.ExprFilter isBoundInGoal <- getIsBoundFilter' goal
-  eqRel <- CMR.asks envBaseEquiv
   result <- PRt.zipWithRegStatesPar (PSi.simRegs inStO) (PSi.simRegs inStP) $ \r vO vP -> do
       isInO <- liftFilterMacaw isBoundInGoal vO
       isInP <- liftFilterMacaw isBoundInGoal vP
@@ -319,7 +318,7 @@ guessEquivalenceDomain bundle goal postcond = startTimer $ withSym $ \sym -> do
   goal' <- liftIO $ WEH.applyExprBindings sym memP_to_memP' goal_regsEq
 
   stackDom <- guessMemoryDomain bundle_regsEq goal_regsEq (memP', goal') (PED.eqDomainStackMemory postcond_regsEq) (\c -> isStackCell c)
-  let stackEq = liftIO $ PEq.memDomPre sym (PEq.MemRegionEquality $ MT.memEqAtRegion sym stackRegion) inO inP (PEq.eqRelStack eqRel) stackDom
+  let stackEq = liftIO $ PEq.memDomPre sym (PEq.MemEqAtRegion stackRegion) inO inP stackDom
   memDom <- withAssumption_ stackEq $ do
     guessMemoryDomain bundle_regsEq goal_regsEq (memP', goal') (PED.eqDomainGlobalMemory postcond_regsEq) (\x -> isNotStackCell x)
 

--- a/src/Pate/Verification/PairGraph.hs
+++ b/src/Pate/Verification/PairGraph.hs
@@ -866,7 +866,7 @@ findUnequalRegs sym evalFn eqCtx regPred oRegs pRegs =
             let pRegEq  = PER.registerInDomain sym regName regPred
             regEq <- liftIO (W4.groundEval evalFn pRegEq)
             when regEq $
-              do isEqPred <- liftIO (applyRegEquiv sym eqCtx regName oRegVal pRegVal)
+              do isEqPred <- liftIO (registerValuesEqual sym eqCtx regName oRegVal pRegVal)
                  isEq <- liftIO (W4.groundEval evalFn isEqPred)
                  when (not isEq) (tell [Some regName]))
     oRegs


### PR DESCRIPTION
this was not properly supported, and in general most of the code
assumed that given equivalence relation was only ever exact equality

fixes #213