### PR TITLE
Implement JSON reports for differential summaries

### DIFF
--- a/demos/Makefile
+++ b/demos/Makefile
@@ -65,6 +65,7 @@ challenge03: challenge03-variant/challenge03.orig.exe challenge03-variant/challe
 							   --log-file challenge03.out \
 							   --verbosity Debug \
 							   --noproofs \
+                 --proof-summary-json=challenge03-result.json \
 							   --ignoremain
 
 .PHONY: abort


### PR DESCRIPTION
With this change, we have a concise way to report to users both differential
summaries and inlined memory differences without requiring users to trawl
through the text output.

Note that we could probably stand to improve the formatting of formulas (it is
currently just the printed output from what4).

Fixes #177