### PR TITLE
don't print duplicate cells in counter-example

### DIFF
--- a/pate.cabal
+++ b/pate.cabal
@@ -59,6 +59,7 @@ common shared
                        unliftio-core >= 0.2 && < 0.3,
                        unliftio >= 0.2 && < 0.3,
                        unordered-containers,
+                       semmc,
                        text >= 1 && < 1.3,
                        tomland >= 1.3 && < 1.4,
                        transformers,


### PR DESCRIPTION
we need to explicitly check for equality with
respect to the grounding environment, as the grounded
variant is what we are displaying