### PR TITLE
Remove an unnecessary use of unsafeCoerce

### DIFF
--- a/src/Pate/Ground.hs
+++ b/src/Pate/Ground.hs
@@ -67,7 +67,6 @@ import qualified Pate.Solver as PS
 import qualified What4.Expr.GroundEval as W4G
 import qualified What4.Interface as W4
 import qualified What4.Partial as W4P
-import qualified What4.ExprHelpers as WEH
 
 import qualified SemMC.Util as SU
 
@@ -160,8 +159,8 @@ groundInfo e = withGroundData $ \grnd -> case SU.exprToGroundVal @sym (W4.exprTy
 -- | Retrieve the ground information of a symbolic natural with respect to the
 -- grounding environment bound by 'IsGroundSym'
 groundInfoNat :: IsGroundSym sym => W4.SymNat sym -> (MT.UndefPtrOpTags, Natural)
-groundInfoNat e = withGroundData $ \grnd ->
-  let info = groundInfo $ WEH.natToIntegerPure (grndSym grnd) e
+groundInfoNat e = withGroundData $ \_grnd ->
+  let info = groundInfo $ W4.natToIntegerPure e
   in (groundPtrTag info, integerToNat (groundVal info))
 
 -- TODO: this breaks the abstraction boundary for block ends

--- a/src/What4/ExprHelpers.hs
+++ b/src/What4/ExprHelpers.hs
@@ -63,11 +63,10 @@ module What4.ExprHelpers (
   , setProgramLoc
   , idxCacheEvalWriter
   , Tagged
-  , natToIntegerPure
   ) where
 
 import           GHC.TypeNats
-import           Unsafe.Coerce -- for mulMono axiom
+import           Unsafe.Coerce ( unsafeCoerce ) -- for mulMono axiom
 
 import           Control.Applicative
 import           Control.Monad.Except
@@ -108,13 +107,6 @@ import qualified What4.Symbol as WS
 
 import           Data.Parameterized.SetF (SetF)
 import qualified Data.Parameterized.SetF as SetF
-
-
--- FIXME: this is a workaround for the fact that 'natToInteger' from What4.Interface
--- is in the IO monad, but doesn't need to be.
-natToIntegerPure ::
-  W4.IsExprBuilder sym => sym -> W4.SymNat sym -> W4.SymInteger sym
-natToIntegerPure _sym n = unsafeCoerce n
 
 iteM ::
   W4.IsExprBuilder sym =>


### PR DESCRIPTION
The necessary helper was implemented in what4, so we can get rid of this use of
`unsafeCoerce`.

Fixes #291