### PR TITLE
Fix PowerPC 32 handling

### DIFF
--- a/tests/PPC32TestMain.hs
+++ b/tests/PPC32TestMain.hs
@@ -19,21 +19,9 @@ main = do
         , testExpectEquivalenceFailure =
             [
               "const-args"
-
-              -- failing due to macaw analysis failures:
-              -- see: https://github.com/GaloisInc/pate/issues/128
-            , "reorder-call"
-            , "args-equal"
-            , "reestablish-equality"
             ]
         , testExpectSelfEquivalenceFailure =
             [
-              -- failing due to macaw analysis failures:
-              -- see: https://github.com/GaloisInc/pate/issues/128
-              "const-args"
-            , "reorder-call"
-            , "args-equal"
-            , "reestablish-equality"
             ]
         -- TODO: we should define a section name here and read its address
         -- from the ELF


### PR DESCRIPTION
The real fix is in the updated macaw submodule[1]; the problem was due to
incorrect sign extension in the abstract domains used for code discovery.

Fixes #128

[1] https://github.com/GaloisInc/macaw/commit/92966921385e533e0ebbb6f583d798678b37505b