### PR TITLE
Handle timeouts when using the online solver

### DIFF
--- a/src/Pate/Equivalence.hs
+++ b/src/Pate/Equivalence.hs
@@ -75,6 +75,7 @@ import qualified Pate.Register.Traversal as PRt
 import           Pate.SimState
 import qualified Pate.SimulatorRegisters as PSR
 import           What4.ExprHelpers
+import qualified Pate.Equivalence.Error as PEE
 import qualified Pate.Equivalence.MemoryDomain as PEM
 import qualified Pate.Equivalence.RegisterDomain as PER
 import qualified Pate.Equivalence.EquivalenceDomain as PED
@@ -83,8 +84,9 @@ data EquivalenceStatus =
     Equivalent
   | Inequivalent
   | ConditionallyEquivalent
-  | Errored String
-  deriving (Show)
+  | forall arch. PA.ValidArch arch => Errored (PEE.EquivalenceError arch)
+
+deriving instance Show EquivalenceStatus
 
 instance Semigroup EquivalenceStatus where
   Errored err <> _ = Errored err

--- a/src/Pate/Equivalence.hs
+++ b/src/Pate/Equivalence.hs
@@ -53,17 +53,13 @@ module Pate.Equivalence
 
 import           Control.Lens hiding ( op, pre )
 import           Control.Monad ( foldM )
-import           Control.Monad.IO.Class ( liftIO )
 import           Data.Parameterized.Classes
-import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Some
 import qualified Data.Set as S
-import           GHC.Stack ( HasCallStack )
 import qualified What4.Interface as W4
 
 import qualified Data.Macaw.CFG as MM
 import qualified Lang.Crucible.LLVM.MemModel as CLM
-import qualified Lang.Crucible.Types as CT
 import           Lang.Crucible.Backend (IsSymInterface)
 
 import qualified Pate.Arch as PA

--- a/src/Pate/Equivalence/Error.hs
+++ b/src/Pate/Equivalence/Error.hs
@@ -12,6 +12,7 @@ module Pate.Equivalence.Error (
   , SimpResult(..)
   , equivalenceError
   , equivalenceErrorFor
+  , isRecoverable
   ) where
 
 import qualified Control.Exception as X
@@ -81,6 +82,14 @@ data InnerEquivalenceError arch
   | InconsistentSimplificationResult SimpResult
   | UnhandledLoop
   | MissingExpectedEquivalentFunction (PA.ConcreteAddress arch)
+  | SolverStackMisalignment
+  | LoaderFailure String
+
+-- | Roughly categorizing how catastrophic an error is to the soundness of the verifier
+isRecoverable :: InnerEquivalenceError arch -> Bool
+isRecoverable e = case e of
+  InconsistentSimplificationResult{} -> True
+  _ -> False
 
 data SimpResult = forall sym tp. W4.IsExpr (W4.SymExpr sym) =>
   SimpResult (Proxy sym) (W4.SymExpr sym tp) (W4.SymExpr sym tp)

--- a/src/Pate/Event.hs
+++ b/src/Pate/Event.hs
@@ -110,3 +110,4 @@ data Event arch where
   GasExhausted :: (PArch.ValidArch arch) => PVPN.GraphNode arch -> Event arch
   -- | Other errors that can occur inside of the strongest postcondition verifier
   StrongestPostMiscError :: (PArch.ValidArch arch) => PVPN.GraphNode arch -> T.Text -> Event arch
+  VisitedNode :: (PArch.ValidArch arch) => PVPN.GraphNode arch -> TM.NominalDiffTime -> Event arch

--- a/src/Pate/Metrics.hs
+++ b/src/Pate/Metrics.hs
@@ -96,3 +96,4 @@ summarize e m =
     PE.StrongestPostMiscError {} -> m
     PE.StrongestPostOverallResult {} -> m
     PE.GasExhausted {} -> m
+    PE.VisitedNode{} -> m

--- a/src/Pate/Monad.hs
+++ b/src/Pate/Monad.hs
@@ -81,8 +81,6 @@ module Pate.Monad
   -- equivalence
   , equivalenceContext
   , safeIO
-  , goalSat
-  , heuristicSat
   , concretizeWithSolver
   )
   where
@@ -586,7 +584,7 @@ concretizeWithSolver ::
   EquivM sym arch (W4.SymExpr sym tp)
 concretizeWithSolver e = withSym $ \sym -> do
   heuristicTimeout <- CMR.asks (PC.cfgHeuristicTimeout . envConfig)
-  let wsolver = PVC.WrappedSolver sym $ \desc p k -> do
+  let wsolver = PVC.WrappedSolver sym $ \_desc p k -> do
         r <- checkSatisfiableWithModel heuristicTimeout "concretizeWithSolver" p $ \res -> IO.withRunInIO $ \inIO -> do
           res' <- W4R.traverseSatResult (\r' -> return $ W4G.GroundEvalFn (\e' -> inIO (execGroundFn r' e'))) pure res
           inIO (k res')

--- a/src/Pate/Monad/Environment.hs
+++ b/src/Pate/Monad/Environment.hs
@@ -52,6 +52,7 @@ import qualified Pate.Verification.Override.Library as PVOL
 data VerificationFailureMode =
     ThrowOnAnyFailure
   | ContinueAfterFailure
+  | ContinueAfterRecoverableFailures
 
 data EquivEnv sym arch where
   EquivEnv ::

--- a/src/Pate/Verification.hs
+++ b/src/Pate/Verification.hs
@@ -48,8 +48,6 @@ import           Prelude hiding ( fail )
 import qualified What4.Expr as WE
 import qualified What4.FunctionName as WF
 import qualified What4.Interface as W4
-import           System.IO
-import           Data.IORef
 
 import qualified Data.Macaw.BinaryLoader as MBL
 import qualified Data.Macaw.CFG as MM

--- a/src/Pate/Verification.hs
+++ b/src/Pate/Verification.hs
@@ -48,6 +48,8 @@ import           Prelude hiding ( fail )
 import qualified What4.Expr as WE
 import qualified What4.FunctionName as WF
 import qualified What4.Interface as W4
+import           System.IO
+import           Data.IORef
 
 import qualified Data.Macaw.BinaryLoader as MBL
 import qualified Data.Macaw.CFG as MM
@@ -242,7 +244,7 @@ doVerifyPairs validArch logAction elf elf' vcfg pd gen sym = do
           , envBlockEndVar = bvar
           , envLogger = logAction
           , envConfig = vcfg
-          , envFailureMode = PME.ThrowOnAnyFailure
+          , envFailureMode = PME.ContinueAfterFailure
           , envValidSym = PS.Sym symNonce sym bak
           , envStartTime = startedAt
           , envCurrentFrame = Some mempty

--- a/src/Pate/Verification/DemandDiscovery.hs
+++ b/src/Pate/Verification/DemandDiscovery.hs
@@ -287,7 +287,7 @@ lookupFunction bak argMap overrides symtab pfm archVals loadedBinary = DMS.Looku
   --
   -- Note that if there are multiple actual values, this will remain a symbolic
   -- term and we will fail (because Crucible cannot yet mux function handles).
-  singletonIP <- PVC.resolveSingletonSymbolicAs (PVC.concreteBV PN.knownNat) bak ipBV
+  singletonIP <- PVC.resolveSingletonSymbolicAs (PVC.concreteBV PN.knownNat) (PVC.wrappedBackend bak) ipBV
 
   case WI.asBV singletonIP of
     Nothing -> PP.panic PP.InlineCallee "lookupFunction" ["Non-constant target IP for call: " ++ show (WI.printSymExpr singletonIP)]

--- a/src/Pate/Verification/MemoryLog.hs
+++ b/src/Pate/Verification/MemoryLog.hs
@@ -169,16 +169,16 @@ concretizeWrites bak fp = do
     sym = LCB.backendGetSym bak
 
     concFree r =
-      WI.integerToNat sym =<< PVC.resolveSingletonSymbolicAs PVC.concreteInteger bak =<< WI.natToInteger sym r
+      WI.integerToNat sym =<< PVC.resolveSingletonSymbolicAs PVC.concreteInteger (PVC.wrappedBackend bak) =<< WI.natToInteger sym r
 
     concWrite mw =
       case mw of
         UnboundedWrite ptr -> do
-          ptr' <- PVC.resolveSingletonPointer bak ptr
+          ptr' <- PVC.resolveSingletonPointer (PVC.wrappedBackend bak) ptr
           return (UnboundedWrite ptr')
         MemoryWrite rsn w ptr len -> do
-          ptr' <- PVC.resolveSingletonPointer bak ptr
-          len' <- PVC.resolveSingletonSymbolicAs (PVC.concreteBV w) bak len
+          ptr' <- PVC.resolveSingletonPointer (PVC.wrappedBackend bak) ptr
+          len' <- PVC.resolveSingletonSymbolicAs (PVC.concreteBV w) (PVC.wrappedBackend bak) len
           return (MemoryWrite rsn w ptr' len')
 
 emptyFootprint :: Footprint sym

--- a/src/Pate/Verification/Override/Library.hs
+++ b/src/Pate/Verification/Override/Library.hs
@@ -204,8 +204,8 @@ doMemcpy ovCfg bak (Ctx.Empty Ctx.:> (LCS.regValue -> dest) Ctx.:> (LCS.regValue
     destPtr <- mapPtr (LCLM.llvmPointerBlock dest) (LCLM.llvmPointerOffset dest)
     srcPtr <- mapPtr (LCLM.llvmPointerBlock src) (LCLM.llvmPointerOffset src)
 
-    destPtr' <- PVC.resolveSingletonPointer bak destPtr
-    srcPtr' <- PVC.resolveSingletonPointer bak srcPtr
+    destPtr' <- PVC.resolveSingletonPointer (PVC.wrappedBackend bak) destPtr
+    srcPtr' <- PVC.resolveSingletonPointer (PVC.wrappedBackend bak) srcPtr
 
     nBytesBV <- LCLM.projectLLVM_bv bak nBytes
 
@@ -254,7 +254,7 @@ doMemset ovCfg bak (Ctx.Empty Ctx.:> (LCS.regValue -> dest) Ctx.:> (LCS.regValue
     let mapPtr = DMSM.applyGlobalMap (DMSM.mapRegionPointers (ocPointerMap ovCfg)) bak mem
 
     destPtr <- mapPtr (LCLM.llvmPointerBlock dest) (LCLM.llvmPointerOffset dest)
-    destPtr' <- PVC.resolveSingletonPointer bak destPtr
+    destPtr' <- PVC.resolveSingletonPointer (PVC.wrappedBackend bak) destPtr
 
     valBV <- LCLM.projectLLVM_bv bak val
     fillByteBV <- WI.bvTrunc sym (PN.knownNat @8) valBV

--- a/src/Pate/Verification/SimulatorHooks.hs
+++ b/src/Pate/Verification/SimulatorHooks.hs
@@ -204,7 +204,7 @@ concretizingWrite memVar globs bak crucState _addrWidth memRep (LCS.regValue -> 
   mem <- getMem crucState memVar
   -- Attempt to concretize the pointer we are writing to, so that we can minimize symbolic writes
   ptr' <- tryGlobPtr bak mem globs ptr
-  ptr'' <- PVC.resolveSingletonPointer bak ptr'
+  ptr'' <- PVC.resolveSingletonPointer (PVC.wrappedBackend bak) ptr'
   ty <- memReprToStorageType memRep
   let memVal = resolveMemVal memRep ty value
   mem' <- LCLM.storeRaw bak mem ptr'' ty LCLD.noAlignment memVal
@@ -240,7 +240,7 @@ concretizingRead memVar globs bak crucState _addrWidth memRep (LCS.regValue -> p
   -- Attempt to concretize the pointer we are reading from, avoiding a symbolic
   -- read if possible
   ptr' <- tryGlobPtr bak mem globs ptr
-  ptr''@(LCLM.LLVMPointer _ off) <- PVC.resolveSingletonPointer bak ptr'
+  ptr''@(LCLM.LLVMPointer _ off) <- PVC.resolveSingletonPointer (PVC.wrappedBackend bak) ptr'
   case WI.asBV off of
     Just _ -> do
       ty <- memReprToStorageType memRep

--- a/src/Pate/Verification/StrongestPosts.hs
+++ b/src/Pate/Verification/StrongestPosts.hs
@@ -19,7 +19,7 @@ module Pate.Verification.StrongestPosts
 
 import qualified Control.Concurrent.MVar as MVar
 import           Control.Lens ( view, (^.) )
-import           Control.Monad (foldM, forM, forM_)
+import           Control.Monad (foldM, forM)
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader (asks)
 import           Control.Monad.Except (runExceptT, catchError)
@@ -39,8 +39,6 @@ import qualified Data.Parameterized.TraversableF as TF
 
 import qualified What4.Expr as W4
 import qualified What4.Interface as W4
-import qualified What4.Protocol.Online as W4
-import qualified What4.Protocol.SMTWriter as W4 hiding ( bvAdd )
 import           What4.SatResult (SatResult(..))
 
 import qualified Lang.Crucible.Backend as LCB

--- a/src/Pate/Verification/Widening.hs
+++ b/src/Pate/Verification/Widening.hs
@@ -83,7 +83,7 @@ makeFreshAbstractDomain ::
   EquivM sym arch (PAD.AbstractDomainSpec sym arch)
 makeFreshAbstractDomain scope bundle preDom from to = do
   dom <- case from of
-    GraphNode{} -> do
+    GraphNode{} -> startTimer $ do
       initDom <- initialDomain
       vals <- withOnlineBackend $ \bak ->
         liftIO $ getInitalAbsDomainVals bak bundle preDom

--- a/tests/TestBase.hs
+++ b/tests/TestBase.hs
@@ -152,6 +152,12 @@ doTest mwb cfg sv proxy@(PA.SomeValidArch {}) fp = do
                     True -> show oAddr
                     False -> "(" ++ show oAddr ++ "," ++ show pAddr ++ ")"
               addLogMsg $ addr ++ ":" ++ show msg
+            PE.StrongestPostDesync pPair _ ->
+              addLogMsg $ "Desync at: " ++ show pPair
+            PE.StrongestPostObservable pPair _ ->
+              addLogMsg $ "Observable counterexample at: " ++ show pPair
+            PE.StrongestPostOverallResult status _ ->
+              addLogMsg $ "Overall Result:" ++ show status
             _ -> return ()
       }
   result <- case mwb of


### PR DESCRIPTION
This adds some error handling surrounding the use of the `timeout` primitive for querying the solver, since we need to do some cleanup when the underlying solver process is killed.