### PR TITLE
Various optimizations

### DIFF
--- a/pate.cabal
+++ b/pate.cabal
@@ -109,6 +109,7 @@ library
                        Pate.Hints.CSV,
                        Pate.Hints.JSON,
                        Pate.Hints.DWARF,
+                       Pate.Location,
                        Pate.Monad,
                        Pate.Monad.Context,
                        Pate.Monad.Environment,

--- a/src/Pate/Block.hs
+++ b/src/Pate/Block.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
 module Pate.Block (
   -- * Block data
     BlockEntryKind(..)
@@ -29,6 +30,7 @@ import qualified Data.ByteString.Char8 as BSC
 import qualified Data.Macaw.CFG as MM
 import qualified Data.Macaw.CFGSlice as MCS
 import qualified Data.Parameterized.Classes as PC
+
 import qualified Prettyprinter as PP
 
 import qualified Pate.Address as PA
@@ -147,7 +149,15 @@ data BlockTarget arch bin =
     , targetReturn :: Maybe (ConcreteBlock arch bin)
     -- | The expected block exit case when this target is taken
     , targetEndCase :: MCS.MacawBlockEndCase
-    }
+    } deriving (Eq, Ord)
+
+instance PC.TestEquality (BlockTarget arch) where
+  testEquality e1 e2 = PC.orderingF_refl (PC.compareF e1 e2)
+
+instance PC.OrdF (BlockTarget arch) where
+  compareF e1 e2 = case PC.compareF (blockBinRepr $ targetCall e1) (blockBinRepr $ targetCall e2) of
+    PC.EQF -> PC.fromOrdering (compare e1 e2)
+    x -> x
 
 instance MM.MemWidth (MM.ArchAddrWidth arch) => Show (BlockTarget arch bin) where
   show (BlockTarget a b _) = "BlockTarget (" ++ show a ++ ") " ++ "(" ++ show b ++ ")"

--- a/src/Pate/Block.hs
+++ b/src/Pate/Block.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE StandaloneDeriving #-}
 module Pate.Block (
   -- * Block data
     BlockEntryKind(..)

--- a/src/Pate/Config.hs
+++ b/src/Pate/Config.hs
@@ -10,7 +10,8 @@ module Pate.Config (
   MemRegion(..),
   parsePatchConfig,
   VerificationConfig(..),
-  defaultVerificationCfg
+  defaultVerificationCfg,
+  VerificationFailureMode(..)
   ) where
 
 import qualified Control.Monad.Except as CME
@@ -196,6 +197,11 @@ parsePatchConfig bs = CME.runExcept $ do
   txt <- liftExcept UnicodeError (DTE.decodeUtf8' bs)
   liftExcept TOMLError (Toml.decode patchDataCodec txt)
 
+data VerificationFailureMode =
+    ThrowOnAnyFailure
+  | ContinueAfterFailure
+  | ContinueAfterRecoverableFailures
+
 ----------------------------------
 -- Verification configuration
 data VerificationConfig =
@@ -221,7 +227,9 @@ data VerificationConfig =
     --
     -- This only captures the interaction with the solver during symbolic
     -- execution, and not the one-off queries issued by the rest of the verifier
-
+    , cfgFailureMode :: VerificationFailureMode
+    -- ^ Determines the behavior of the verifier when an error is thrown,
+    -- with respect to whether or not the error is deemed "recoverable"
     }
 
 defaultVerificationCfg :: VerificationConfig
@@ -234,4 +242,5 @@ defaultVerificationCfg =
                      , cfgGroundTimeout = PT.Seconds 5
                      , cfgMacawDir = Nothing
                      , cfgSolverInteractionFile = Nothing
+                     , cfgFailureMode = ContinueAfterRecoverableFailures
                      }

--- a/src/Pate/Equivalence.hs
+++ b/src/Pate/Equivalence.hs
@@ -437,10 +437,8 @@ instance W4.IsSymExprBuilder sym => PL.LocationTraversable sym arch (RegisterCon
   traverseLocation sym body f = RegisterCondition <$>
     MM.traverseRegsWith (\r (Const asm) -> do
       p <- getAssumedPred sym asm
-      f (PL.Register r) p >>= \case
-        Just (_, p') -> return $ (Const (frameAssume p'))
-        Nothing -> return $ (Const mempty)
-                        ) (regCondPreds body)
+      f (PL.Register r) p >>= \ (_, p') -> return $ (Const (frameAssume p'))
+      ) (regCondPreds body)
 
 
 -- | Compute a structured 'RegisterCondition'

--- a/src/Pate/Equivalence.hs
+++ b/src/Pate/Equivalence.hs
@@ -53,9 +53,6 @@ module Pate.Equivalence
 
 import           Control.Lens hiding ( op, pre )
 import           Control.Monad ( foldM )
-import           Control.Monad.Trans.Except ( throwE, runExceptT )
-import           Control.Monad.Trans ( lift )
-import           Control.Monad.IO.Class ( MonadIO, liftIO )
 import           Data.Parameterized.Classes
 import           Data.Parameterized.Some
 import qualified Data.Set as S

--- a/src/Pate/Equivalence.hs
+++ b/src/Pate/Equivalence.hs
@@ -53,12 +53,9 @@ module Pate.Equivalence
 
 import           Control.Lens hiding ( op, pre )
 import           Control.Monad ( foldM )
-<<<<<<< HEAD
-=======
 import           Control.Monad.Trans.Except ( throwE, runExceptT )
 import           Control.Monad.Trans ( lift )
 import           Control.Monad.IO.Class ( MonadIO, liftIO )
->>>>>>> 3772b3e (add Pate.Location for general traversals)
 import           Data.Parameterized.Classes
 import           Data.Parameterized.Some
 import qualified Data.Set as S
@@ -483,54 +480,11 @@ data StateCondition sym arch v = StateCondition
   , stMemCond :: MemoryCondition sym arch
   }
 
-<<<<<<< HEAD
-=======
 instance W4.IsSymExprBuilder sym => PL.LocationTraversable sym arch (StateCondition sym arch v) where
   traverseLocation sym (StateCondition a b c) f =
     StateCondition <$> PL.traverseLocation sym a f <*> PL.traverseLocation sym b f <*> PL.traverseLocation sym c f
 
 
-{-
--- | Traverse the locations in a 'StateCondition' and evaluate
--- the given action against each predicate, yielding the first successful
--- result
-firstStateCondition ::
-  MonadIO m =>
-  IsSymInterface sym =>
-  sym ->
-  W4.Pred sym ->
-  StateCondition sym arch v ->
-  (Location sym arch -> W4.Pred sym -> m (Maybe a)) ->
-  m (Maybe a)
-firstStateCondition sym firstTry cond f = do
-  r <- runExceptT $ do
-    (lift $ f NoLocation firstTry) >>= \case
-      Just a -> throwE a
-      Nothing -> return ()
-    _ <- MM.traverseRegsWith (\r (Const asm) -> do
-                            p <- getAssumedPred sym asm
-                            ma <- lift $ f (RegLocation r) p
-                            case ma of
-                              Just a -> throwE a
-                              Nothing -> return $ (Const asm)) (regCondPreds $ (stRegCond cond))
-
-    _ <- PEM.traverseWithCell (memCondDomain $ stStackCond cond) $ \cell p -> do
-      ma <- lift $ f (MemLocation cell) p
-      case ma of
-        Just a -> throwE a
-        Nothing -> return p
-    _ <- PEM.traverseWithCell (memCondDomain $ stMemCond cond) $ \cell p -> do
-      ma <- lift $ f (MemLocation cell) p
-      case ma of
-        Just a -> throwE a
-        Nothing -> return p
-    return ()
-  case r of
-    Left a -> return $ Just a
-    Right () -> return Nothing
--}
-
->>>>>>> 3772b3e (add Pate.Location for general traversals)
 eqDomPre ::
   IsSymInterface sym =>
   PA.ValidArch arch =>

--- a/src/Pate/Equivalence/EquivalenceDomain.hs
+++ b/src/Pate/Equivalence/EquivalenceDomain.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Pate.Equivalence.EquivalenceDomain (
     EquivalenceDomain(..)
   , mux
@@ -22,6 +24,7 @@ import qualified Pate.Solver as PS
 import qualified Pate.Equivalence.MemoryDomain as PEM
 import qualified Pate.Equivalence.RegisterDomain as PER
 import qualified Pate.ExprMappable as PEM
+import qualified Pate.Location as PL
 
 ---------------------------------------------
 -- Equivalence domain
@@ -37,6 +40,10 @@ data EquivalenceDomain sym arch where
       -- | The memory domain that is specific to non-stack (i.e. global) variables.
     , eqDomainGlobalMemory :: PEM.MemoryDomain sym arch
     }  -> EquivalenceDomain sym arch
+
+instance (WI.IsExprBuilder sym, OrdF (WI.SymExpr sym), MM.RegisterInfo (MM.ArchReg arch)) => PL.LocationTraversable sym arch (EquivalenceDomain sym arch) where
+  traverseLocation sym (EquivalenceDomain a b c) f = EquivalenceDomain <$> PL.traverseLocation sym a f <*> PL.traverseLocation sym b f <*> PL.traverseLocation sym c f
+
 
 ppEquivalenceDomain ::
   forall sym arch a.

--- a/src/Pate/Equivalence/EquivalenceDomain.hs
+++ b/src/Pate/Equivalence/EquivalenceDomain.hs
@@ -41,8 +41,8 @@ data EquivalenceDomain sym arch where
     , eqDomainGlobalMemory :: PEM.MemoryDomain sym arch
     }  -> EquivalenceDomain sym arch
 
-instance (WI.IsExprBuilder sym, OrdF (WI.SymExpr sym), MM.RegisterInfo (MM.ArchReg arch)) => PL.LocationTraversable sym arch (EquivalenceDomain sym arch) where
-  traverseLocation sym (EquivalenceDomain a b c) f = EquivalenceDomain <$> PL.traverseLocation sym a f <*> PL.traverseLocation sym b f <*> PL.traverseLocation sym c f
+instance (WI.IsExprBuilder sym, OrdF (WI.SymExpr sym), MM.RegisterInfo (MM.ArchReg arch)) => PL.LocationWitherable sym arch (EquivalenceDomain sym arch) where
+  witherLocation sym (EquivalenceDomain a b c) f = EquivalenceDomain <$> PL.witherLocation sym a f <*> PL.witherLocation sym b f <*> PL.witherLocation sym c f
 
 
 ppEquivalenceDomain ::

--- a/src/Pate/Equivalence/Error.hs
+++ b/src/Pate/Equivalence/Error.hs
@@ -84,6 +84,9 @@ data InnerEquivalenceError arch
   | MissingExpectedEquivalentFunction (PA.ConcreteAddress arch)
   | SolverStackMisalignment
   | LoaderFailure String
+  | WideningError String
+  | ObservabilityError String
+  | TotalityError String
 
 -- | Roughly categorizing how catastrophic an error is to the soundness of the verifier
 isRecoverable :: InnerEquivalenceError arch -> Bool

--- a/src/Pate/Equivalence/Error.hs
+++ b/src/Pate/Equivalence/Error.hs
@@ -87,11 +87,26 @@ data InnerEquivalenceError arch
   | WideningError String
   | ObservabilityError String
   | TotalityError String
+  | forall sym v tp pre post. W4.IsExpr (W4.SymExpr sym) => RescopingFailure (PS.AssumptionSet sym v) (PS.ScopedExpr sym pre tp) (PS.ScopedExpr sym post tp)
+
+ppInnerError :: MS.SymArchConstraints arch => InnerEquivalenceError arch -> PP.Doc a
+ppInnerError e = case e of
+  RescopingFailure asms src tgt ->
+    PP.vsep
+      [ "Unable to rescope:"
+      , PP.pretty asms
+      , "Source Expression"
+      , PP.pretty src
+      , "Target Expression"
+      , PP.pretty tgt
+      ]
+  _ -> PP.viaShow e
 
 -- | Roughly categorizing how catastrophic an error is to the soundness of the verifier
 isRecoverable :: InnerEquivalenceError arch -> Bool
 isRecoverable e = case e of
   InconsistentSimplificationResult{} -> True
+  RescopingFailure{} -> True
   _ -> False
 
 data SimpResult = forall sym tp. W4.IsExpr (W4.SymExpr sym) =>
@@ -121,7 +136,7 @@ instance PP.Pretty (EquivalenceError arch) where
   pretty e@(EquivalenceError{}) = PP.vsep $ catMaybes $
     [ fmap (\(Some b) -> "For " <+> PP.pretty (show b) <+> " binary") (errWhichBinary e)
     , fmap (\s -> "At " <+> PP.pretty (prettyCallStack s)) (errStackTrace e)
-    , Just (PP.pretty (errEquivError e))
+    , Just (ppInnerError (errEquivError e))
     ]
 
 instance Show (EquivalenceError arch) where

--- a/src/Pate/Equivalence/MemoryDomain.hs
+++ b/src/Pate/Equivalence/MemoryDomain.hs
@@ -8,6 +8,8 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE LambdaCase   #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Pate.Equivalence.MemoryDomain (
     MemoryDomain
@@ -27,6 +29,7 @@ module Pate.Equivalence.MemoryDomain (
   ) where
 
 import           Control.Monad ( forM, join )
+import qualified Control.Monad.IO.Class as IO
 import qualified Data.Map as M
 import           Data.Maybe (catMaybes)
 import           Data.Parameterized.Classes
@@ -44,6 +47,7 @@ import qualified Pate.ExprMappable as PEM
 import qualified Pate.MemCell as PMC
 import qualified Pate.Memory.MemTrace as MT
 import qualified Pate.Parallel as Par
+import qualified Pate.Location as PL
 
 ---------------------------------------------
 -- Memory domain
@@ -75,6 +79,12 @@ traverseWithCellPar memDom f = do
   Par.present $ do
     preds <- PMC.MemCellPred <$> traverse Par.joinFuture future_preds
     return $ MemoryDomain preds
+
+instance (W4.IsExprBuilder sym, OrdF (W4.SymExpr sym)) => PL.LocationTraversable sym arch (MemoryDomain sym arch) where
+  traverseLocation sym d f = fmap MemoryDomain $ PMC.rebuild sym (memDomainPred d) $ \cell p -> do
+    f (PL.Cell cell) p >>= \case
+      Just (PL.Cell cell', p') -> return $ Just (cell', p')
+      _ -> return Nothing
 
       
 traverseWithCell ::

--- a/src/Pate/Equivalence/MemoryDomain.hs
+++ b/src/Pate/Equivalence/MemoryDomain.hs
@@ -29,7 +29,6 @@ module Pate.Equivalence.MemoryDomain (
   ) where
 
 import           Control.Monad ( forM, join )
-import qualified Control.Monad.IO.Class as IO
 import qualified Data.Map as M
 import           Data.Maybe (catMaybes)
 import           Data.Parameterized.Classes

--- a/src/Pate/Equivalence/MemoryDomain.hs
+++ b/src/Pate/Equivalence/MemoryDomain.hs
@@ -79,11 +79,11 @@ traverseWithCellPar memDom f = do
     preds <- PMC.MemCellPred <$> traverse Par.joinFuture future_preds
     return $ MemoryDomain preds
 
+instance (W4.IsExprBuilder sym, OrdF (W4.SymExpr sym)) => PL.LocationWitherable sym arch (MemoryDomain sym arch) where
+  witherLocation sym (MemoryDomain mp) f = MemoryDomain <$> PL.witherLocation sym mp f
+
 instance (W4.IsExprBuilder sym, OrdF (W4.SymExpr sym)) => PL.LocationTraversable sym arch (MemoryDomain sym arch) where
-  traverseLocation sym d f = fmap MemoryDomain $ PMC.rebuild sym (memDomainPred d) $ \cell p -> do
-    f (PL.Cell cell) p >>= \case
-      Just (PL.Cell cell', p') -> return $ Just (cell', p')
-      _ -> return Nothing
+  traverseLocation sym d f = PL.witherLocation sym d (\loc v -> Just <$> f loc v)
 
       
 traverseWithCell ::

--- a/src/Pate/Equivalence/RegisterDomain.hs
+++ b/src/Pate/Equivalence/RegisterDomain.hs
@@ -67,7 +67,7 @@ traverseWithReg (RegisterDomain dom) f =
       f' (Some reg) p = f reg p
 
 instance (WI.IsExprBuilder sym, MM.RegisterInfo (MM.ArchReg arch)) => PL.LocationTraversable sym arch (RegisterDomain sym arch) where
-  traverseLocation sym (RegisterDomain d) f = do
+  traverseLocation _sym (RegisterDomain d) f = do
     d' <- Map.traverseMaybeWithKey (\(Some r) p -> f (PL.Register r) p >>= \case
             Just (_, p') -> return (Just p')
             Nothing -> return Nothing) d

--- a/src/Pate/Equivalence/RegisterDomain.hs
+++ b/src/Pate/Equivalence/RegisterDomain.hs
@@ -66,8 +66,8 @@ traverseWithReg (RegisterDomain dom) f =
       f' :: Some (MM.ArchReg arch) -> WI.Pred sym -> m (WI.Pred sym)
       f' (Some reg) p = f reg p
 
-instance (WI.IsExprBuilder sym, MM.RegisterInfo (MM.ArchReg arch)) => PL.LocationTraversable sym arch (RegisterDomain sym arch) where
-  traverseLocation _sym (RegisterDomain d) f = do
+instance (WI.IsExprBuilder sym, MM.RegisterInfo (MM.ArchReg arch)) => PL.LocationWitherable sym arch (RegisterDomain sym arch) where
+  witherLocation _sym (RegisterDomain d) f = do
     d' <- Map.traverseMaybeWithKey (\(Some r) p -> f (PL.Register r) p >>= \case
             Just (_, p') -> return (Just p')
             Nothing -> return Nothing) d

--- a/src/Pate/Location.hs
+++ b/src/Pate/Location.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE LambdaCase   #-}
+{-# LANGUAGE QuantifiedConstraints  #-}
+module Pate.Location (
+    Location(..)
+  , LocationTraversable(..)
+  , SingleLocation(..)
+  ) where
+
+import           GHC.TypeLits
+import qualified Control.Monad.IO.Class as IO
+import           Control.Monad.Trans.Except ( throwE, runExceptT )
+import           Control.Monad.Trans.State ( StateT, get, put, execStateT )
+import           Control.Monad.Trans ( lift )
+
+import qualified Data.Macaw.Types as MT
+import qualified Data.Macaw.CFG as MM
+
+import qualified Pate.PatchPair as PPa
+import qualified Pate.MemCell as PMC
+import qualified Pate.ExprMappable as PEM
+import qualified What4.Interface as W4
+
+-- | Generalized location-based traversals
+
+data LocK =
+    RegK MT.Type
+  | CellK Nat
+  | NoLocK
+
+
+data Location sym arch l where
+  Register :: MM.ArchReg arch tp -> Location sym arch ('RegK tp)
+  Cell :: 1 <= w => PMC.MemCell sym arch w -> Location sym arch ('CellK w)
+  -- | A location that does not correspond to any specific state element
+  -- FIXME: currently this is convenient for including additional predicates
+  -- during a location-based traversal, but it shouldn't be necessary once
+  -- all the necessary types are defined to be 'LocationTraversable'
+  NoLoc :: Location sym arch 'NoLocK
+
+instance PEM.ExprMappable sym (Location sym arch l) where
+  mapExpr sym f loc = case loc of
+    Register r -> return $ Register r
+    Cell cell -> Cell <$> PEM.mapExpr sym f cell
+    NoLoc -> return NoLoc
+
+
+-- TODO: this can be abstracted over 'W4.Pred'
+
+-- | Defines 'f' to be viewed as a traversable collection of
+-- 'Location' elements paired with 'W4.Pred' elements.
+class LocationTraversable sym arch f where
+  -- | Traverse 'f' and map each element pair, optionally dropping
+  -- it by returning 'Nothing'
+  traverseLocation ::
+    IO.MonadIO m =>
+    sym ->
+    f ->
+    (forall l. Location sym arch l -> W4.Pred sym -> m (Maybe (Location sym arch l, W4.Pred sym))) ->
+    m f
+
+  -- | Return the first location (according to the traversal order
+  -- defined by 'traverseLocation') where the given function returns
+  -- a 'Just' result
+  firstLocation ::
+    IO.MonadIO m =>
+    sym ->
+    f ->
+    (forall l. Location sym arch l -> W4.Pred sym -> m (Maybe a)) ->
+    m (Maybe a)
+  firstLocation sym body f = do
+    r <- runExceptT $ do
+      _ <- traverseLocation sym body $ \loc v' -> do
+        lift (f loc v') >>= \case
+          Just a -> throwE a
+          Nothing -> return Nothing
+      return ()
+    case r of
+      Left a -> return $ Just a
+      Right () -> return Nothing
+
+  -- | Fold over 'f' (according to its traversal order
+  -- defined by 'traverseLocation')
+  foldLocation ::
+    forall m a.
+    IO.MonadIO m =>
+    sym ->
+    f ->
+    a ->
+    (forall l. a -> Location sym arch l -> W4.Pred sym -> m a) ->
+    m a
+  foldLocation sym body init_ f = execStateT g init_
+    where
+      g :: StateT a m ()
+      g = do
+        _ <- traverseLocation sym body $ \loc v' -> do
+          a <- get
+          a' <- lift (f a loc v')
+          put a'
+          return Nothing
+        return ()
+
+
+-- | Wraps a single 'W4.Pred' as a 'LocationTraversable', where
+-- a 'Just' result is paired with a 'NoLoc' location
+newtype SingleLocation sym = SingleLocation (Maybe (W4.Pred sym))
+
+instance LocationTraversable sym arch (SingleLocation sym) where
+  traverseLocation _sym (SingleLocation (Just p)) f = f NoLoc p >>= \case
+    Just (_, p') -> return $ SingleLocation (Just p')
+    Nothing -> return $ SingleLocation Nothing
+  traverseLocation _sym (SingleLocation Nothing) _f = return $ SingleLocation Nothing
+
+instance (LocationTraversable sym arch a, LocationTraversable sym arch b) =>
+  LocationTraversable sym arch (a, b) where
+  traverseLocation sym (a, b) f = (,) <$> traverseLocation sym a f <*> traverseLocation sym b f
+
+instance (forall bin. (LocationTraversable sym arch (f bin))) =>
+  LocationTraversable sym arch (PPa.PatchPair f) where
+  traverseLocation sym (PPa.PatchPair a b) f = PPa.PatchPair <$> traverseLocation sym a f <*> traverseLocation sym b f

--- a/src/Pate/MemCell.hs
+++ b/src/Pate/MemCell.hs
@@ -17,7 +17,7 @@ module Pate.MemCell (
   , setMemCellRegion
   , MemCellPred(..)
   , traverseWithCell
-  , rebuild
+  , witherCell
   , mergeMemCellPred
   , muxMemCellPred
   , inMemCellPred
@@ -100,7 +100,9 @@ traverseWithCell ::
 traverseWithCell (MemCellPred memPred) f =
   MemCellPred <$> Map.traverseWithKey (\(Some cell@MemCell{}) p -> f cell p) memPred
 
-rebuild ::
+
+-- | Traverse a 'MemCellPred', optionally dropping elements instead of updating them.
+witherCell ::
   forall sym arch m.
   IO.MonadIO m =>
   WI.IsExprBuilder sym =>
@@ -109,7 +111,7 @@ rebuild ::
   MemCellPred sym arch ->
   (forall w. 1 <= w => MemCell sym arch w -> WI.Pred sym -> m (Maybe (MemCell sym arch w, WI.Pred sym))) ->
   m (MemCellPred sym arch)
-rebuild sym (MemCellPred memPred)  f = do
+witherCell sym (MemCellPred memPred)  f = do
   es <- fmap catMaybes $ forM (Map.toList memPred) $ \(Some (cell@MemCell{}), p) -> do
     f cell p >>= \case
       Just (cell', p') -> return $ Just (Some cell', p')

--- a/src/Pate/Metrics.hs
+++ b/src/Pate/Metrics.hs
@@ -97,3 +97,9 @@ summarize e m =
     PE.StrongestPostOverallResult {} -> m
     PE.GasExhausted {} -> m
     PE.VisitedNode{} -> m
+    PE.ErrorEmitted{} -> m
+    PE.SolverEvent{} -> m
+    PE.DomainWidened{} -> m
+    PE.InitialDomainFound{} -> m
+    PE.DomainAbstraction{} -> m
+    PE.ScopeAbstractionResult{} -> m

--- a/src/Pate/Monad.hs
+++ b/src/Pate/Monad.hs
@@ -888,12 +888,12 @@ instance MF.MonadFail (EquivM_ sym arch) where
 manifestError :: EquivM_ sym arch a -> EquivM sym arch (Either (PEE.EquivalenceError arch) a)
 manifestError act = do
   catchError (Right <$> act) (pure . Left) >>= \case
-    r@(Left er) -> CMR.asks envFailureMode >>= \case
-      ThrowOnAnyFailure -> throwError er
-      ContinueAfterRecoverableFailures -> case PEE.isRecoverable (PEE.errEquivError er) of
+    r@(Left er) -> CMR.asks (PC.cfgFailureMode . envConfig) >>= \case
+      PC.ThrowOnAnyFailure -> throwError er
+      PC.ContinueAfterRecoverableFailures -> case PEE.isRecoverable (PEE.errEquivError er) of
         True -> return r
         False -> throwError er
-      ContinueAfterFailure -> return r
+      PC.ContinueAfterFailure -> return r
     r -> return r
 
 -- | Run an IO operation, internalizing any exceptions raised

--- a/src/Pate/Monad/Environment.hs
+++ b/src/Pate/Monad/Environment.hs
@@ -18,6 +18,7 @@ import qualified Control.Lens as L
 
 import           Data.Map (Map)
 import qualified Data.Map as M
+import qualified Data.Set as Set
 import qualified Data.Time as TM
 
 import qualified Data.Parameterized.Nonce as N
@@ -94,7 +95,7 @@ data EquivEnv sym arch where
     -- ^ Overrides to apply in the inline-callee symbolic execution mode
     } -> EquivEnv sym arch
 
-type ExitPairCache arch = BlockCache arch [PPa.PatchPair (PB.BlockTarget arch)]
+type ExitPairCache arch = BlockCache arch (Set.Set (PPa.PatchPair (PB.BlockTarget arch)))
 
 data BlockCache arch a where
   BlockCache :: IO.MVar (Map (PPa.BlockPair arch) a) -> BlockCache arch a

--- a/src/Pate/Monad/Environment.hs
+++ b/src/Pate/Monad/Environment.hs
@@ -9,7 +9,6 @@ module Pate.Monad.Environment (
   , BlockCache(..)
   , freshBlockCache
   , ExitPairCache
-  , VerificationFailureMode(..)
   ) where
 
 import qualified Control.Concurrent as IO
@@ -50,11 +49,6 @@ import qualified Pate.SymbolTable as PSym
 import qualified Pate.Verification.Override as PVO
 import qualified Pate.Verification.Override.Library as PVOL
 
-data VerificationFailureMode =
-    ThrowOnAnyFailure
-  | ContinueAfterFailure
-  | ContinueAfterRecoverableFailures
-
 data EquivEnv sym arch where
   EquivEnv ::
     { envWhichBinary :: Maybe (Some PBi.WhichBinaryRepr)
@@ -70,7 +64,6 @@ data EquivEnv sym arch where
     -- symbolically executing functions in the "inline callee" feature
     , envLogger :: LJ.LogAction IO (PE.Event arch)
     , envConfig :: PC.VerificationConfig
-    , envFailureMode :: VerificationFailureMode
     -- ^ input equivalence problems to solve
     , envValidSym :: PSo.Sym sym
     -- ^ expression builder, wrapped with a validity proof

--- a/src/Pate/Verification.hs
+++ b/src/Pate/Verification.hs
@@ -242,7 +242,6 @@ doVerifyPairs validArch logAction elf elf' vcfg pd gen sym = do
           , envBlockEndVar = bvar
           , envLogger = logAction
           , envConfig = vcfg
-          , envFailureMode = PME.ContinueAfterFailure
           , envValidSym = PS.Sym symNonce sym bak
           , envStartTime = startedAt
           , envCurrentFrame = Some mempty

--- a/src/Pate/Verification/AbstractDomain.hs
+++ b/src/Pate/Verification/AbstractDomain.hs
@@ -93,8 +93,8 @@ data AbstractDomain sym arch (v :: PS.VarScope) where
       -- ^ specifies independent constraints on the values for the original and patched programs
     } -> AbstractDomain sym arch v
 
-instance (W4.IsExprBuilder sym, OrdF (W4.SymExpr sym), PA.ValidArch arch) => PL.LocationTraversable sym arch (AbstractDomain sym arch bin) where
-  traverseLocation sym (AbstractDomain a b) f = AbstractDomain <$> PL.traverseLocation sym a f <*> PL.traverseLocation sym b f
+instance (W4.IsExprBuilder sym, OrdF (W4.SymExpr sym), PA.ValidArch arch) => PL.LocationWitherable sym arch (AbstractDomain sym arch bin) where
+  witherLocation sym (AbstractDomain a b) f = AbstractDomain <$> PL.witherLocation sym a f <*> PL.witherLocation sym b f
 
 
 -- | An 'AbstractDomain' that is closed under a symbolic machine state via
@@ -216,8 +216,8 @@ mergeMemValMaps ::
   MapF.MapF k (MemAbstractValue sym)
 mergeMemValMaps m1 m2 = MapF.mergeWithKey (\_ (MemAbstractValue v1) (MemAbstractValue v2) -> Just $ MemAbstractValue (combineAbsVals v1 v2)) id id m1 m2
 
-instance (W4.IsExprBuilder sym, OrdF (W4.SymExpr sym), PA.ValidArch arch) => PL.LocationTraversable sym arch (AbstractDomainVals sym arch bin) where
-  traverseLocation sym vals f = do
+instance (W4.IsExprBuilder sym, OrdF (W4.SymExpr sym), PA.ValidArch arch) => PL.LocationWitherable sym arch (AbstractDomainVals sym arch bin) where
+  witherLocation sym vals f = do
      rs <- MM.traverseRegsWith (\r v -> f (PL.Register r) (W4.truePred sym) >>= \case
                            Just _ -> return v
                            Nothing -> return $ noAbsVal (MT.typeRepr r)) (absRegVals vals)

--- a/src/Pate/Verification/AbstractDomain.hs
+++ b/src/Pate/Verification/AbstractDomain.hs
@@ -562,7 +562,7 @@ absDomainToPostCond_vals ::
   AbstractDomain sym arch v {- ^ pre-domain for this slice -} ->
   AbstractDomain sym arch v {- ^ target post-domain -} ->
   IO (W4.Pred sym)
-absDomainToPostCond_vals sym eqCtx bundle preDom d = do
+absDomainToPostCond_vals sym eqCtx bundle _preDom d = do
   let PPa.PatchPair valsO valsP = absDomVals d
   predO <- absDomainValsToPred sym eqCtx (PS.simOutState $ PS.simOutO bundle) Nothing valsO
   predP <- absDomainValsToPred sym eqCtx (PS.simOutState $ PS.simOutP bundle) Nothing valsP

--- a/src/Pate/Verification/AbstractDomain.hs
+++ b/src/Pate/Verification/AbstractDomain.hs
@@ -28,6 +28,7 @@ module Pate.Verification.AbstractDomain
   , absDomainValsToPred
   , absDomainToPrecond
   , absDomainToPostCond
+  , absDomainToPostCond_vals
   , ppAbstractDomain
   ) where
 
@@ -563,8 +564,8 @@ absDomainToPostCond_vals ::
   IO (W4.Pred sym)
 absDomainToPostCond_vals sym eqCtx bundle preDom d = do
   let PPa.PatchPair valsO valsP = absDomVals d
-  predO <- absDomainValsToPred sym (PS.simOutState $ PS.simOutO bundle) Nothing valsO
-  predP <- absDomainValsToPred sym (PS.simOutState $ PS.simOutP bundle) Nothing valsP
+  predO <- absDomainValsToPred sym eqCtx (PS.simOutState $ PS.simOutO bundle) Nothing valsO
+  predP <- absDomainValsToPred sym eqCtx (PS.simOutState $ PS.simOutP bundle) Nothing valsP
   W4.andPred sym predO predP
 
 instance PEM.ExprMappable sym (AbstractDomainVals sym arch bin) where

--- a/src/Pate/Verification/PairGraph.hs
+++ b/src/Pate/Verification/PairGraph.hs
@@ -46,7 +46,6 @@ import           Data.Maybe (fromMaybe)
 import           Data.Parameterized.Classes
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Text (Text)
 import           Data.Word (Word32)
 import qualified Lumberjack as LJ
 
@@ -63,7 +62,6 @@ import qualified Pate.Event as Event
 import           Pate.Monad
 import           Pate.Panic
 import qualified Pate.PatchPair as PPa
-import qualified Pate.SimState as PS
 import qualified Pate.Equivalence.Error as PEE
 import qualified Pate.Verification.Domain as PVD
 

--- a/src/Pate/Verification/PairGraph.hs
+++ b/src/Pate/Verification/PairGraph.hs
@@ -64,6 +64,7 @@ import           Pate.Panic
 import qualified Pate.PatchPair as PPa
 import qualified Pate.Equivalence.Error as PEE
 import qualified Pate.Verification.Domain as PVD
+import qualified Pate.SimState as PS
 
 import           Pate.Verification.PairGraph.Node ( GraphNode(..) )
 import           Pate.Verification.StrongestPosts.CounterExample ( TotalityCounterexample(..), ObservableCounterexample(..) )
@@ -169,12 +170,6 @@ data PairGraph sym arch =
   , pairGraphMiscAnalysisErrors :: !(Map (GraphNode arch) [PEE.EquivalenceError arch])
   }
 
-ppAbstractDomainSpec ::
-  (W4.Pred sym -> Doc a) ->
-  AbstractDomainSpec sym arch ->
-  Doc a
-ppAbstractDomainSpec _pPred _spec = pretty "<TODO>"
-
 ppProgramDomains ::
   forall sym arch a.
   ( PA.ValidArch arch
@@ -187,9 +182,9 @@ ppProgramDomains ::
 ppProgramDomains ppPred gr =
   vcat
   [ vcat [ pretty pPair
-         , ppAbstractDomainSpec ppPred ad
+         , PS.viewSpecBody adSpec $ \ad -> PAD.ppAbstractDomain ppPred ad
          ]
-  | (pPair, ad) <- Map.toList (pairGraphDomains gr)
+  | (pPair, adSpec) <- Map.toList (pairGraphDomains gr)
   ]
 
 

--- a/src/Pate/Verification/StrongestPosts.hs
+++ b/src/Pate/Verification/StrongestPosts.hs
@@ -236,8 +236,10 @@ visitNode scope (GraphNode bPair) d gr0 = withPair bPair $ do
   validAbs <- PPa.catBins $ \get -> validAbsValues (get bPair) (get vars)
   withAssumptionSet (validInit <> validAbs) $
     do -- do the symbolic simulation
-       bundle <- mkSimBundle bPair vars d
-       withPredomain bundle d $ do
+       bundle' <- mkSimBundle bPair vars d
+       withPredomain bundle' d $ do
+         -- simplify the bundle under the domain assumptions
+         bundle <- applyCurrentAsms bundle'
  
   {-     traceBundle bundle $ unlines
          [ "== SP result =="

--- a/src/Pate/Verification/StrongestPosts.hs
+++ b/src/Pate/Verification/StrongestPosts.hs
@@ -899,7 +899,7 @@ handlePLTStub ::
   PPa.PatchPair (PB.ConcreteBlock arch) {- ^ return point -} ->
   BS.ByteString {- ^ PLT symbol name -} ->
   EquivM sym arch (PairGraph sym arch)
-handlePLTStub scope bundle currBlock d gr _pPair pRetPair stubSymbol =
+handlePLTStub scope bundle currBlock d gr pPair pRetPair stubSymbol =
   do traceBundle bundle ("Handling PLT stub " ++ show stubSymbol)
 
      -- TODO!! Here we are just assuming the unknown function represented by the PLT stub
@@ -910,7 +910,8 @@ handlePLTStub scope bundle currBlock d gr _pPair pRetPair stubSymbol =
      -- Moreover, we should report this assumption about external functions as potentially leading
      -- to unsoundness.
 
-     handleJump scope bundle currBlock d gr pRetPair
+     --handleJump scope bundle currBlock d gr pRetPair
+     handleOrdinaryFunCall scope bundle currBlock d gr pPair pRetPair
 
 
 handleReturn ::

--- a/src/Pate/Verification/StrongestPosts.hs
+++ b/src/Pate/Verification/StrongestPosts.hs
@@ -234,7 +234,7 @@ visitNode scope (GraphNode bPair) d gr0 = withPair bPair $ do
   withAssumptionSet (validInit <> validAbs) $
     do -- do the symbolic simulation
        bundle <- mkSimBundle bPair vars d
-     
+       withPredomain bundle d $ do
  
   {-     traceBundle bundle $ unlines
          [ "== SP result =="
@@ -244,13 +244,13 @@ visitNode scope (GraphNode bPair) d gr0 = withPair bPair $ do
               (PS.simRegs (PS.simOutState (PPa.pPatched (PS.simOut bundle)))))
          ] -}
 
-       -- Compute exit pairs
-       traceBundle bundle $ "Discovering exit pairs from " ++ (show bPair)
-       -- TODO, manifest errors here?
-       exitPairs <- PD.discoverPairs bundle
-       traceBundle bundle $ (show (length exitPairs) ++ " pairs found!")
+         -- Compute exit pairs
+         traceBundle bundle $ "Discovering exit pairs from " ++ (show bPair)
+         -- TODO, manifest errors here?
+         exitPairs <- PD.discoverPairs bundle
+         traceBundle bundle $ (show (length exitPairs) ++ " pairs found!")
 
-       withPredomain bundle d $ do
+
          gr1 <- checkObservables bPair bundle d gr0
 
          gr2 <- checkTotality bPair bundle d exitPairs gr1

--- a/src/Pate/Verification/StrongestPosts.hs
+++ b/src/Pate/Verification/StrongestPosts.hs
@@ -30,7 +30,6 @@ import qualified Data.BitVector.Sized as BV
 import qualified Data.ByteString as BS
 import qualified Data.Map as Map
 import           Data.Proxy
-import qualified Data.Text as Text
 import           Data.Functor.Const
 
 import           Data.Parameterized.Classes
@@ -899,7 +898,7 @@ handlePLTStub ::
   PPa.PatchPair (PB.ConcreteBlock arch) {- ^ return point -} ->
   BS.ByteString {- ^ PLT symbol name -} ->
   EquivM sym arch (PairGraph sym arch)
-handlePLTStub scope bundle currBlock d gr pPair pRetPair stubSymbol =
+handlePLTStub scope bundle currBlock d gr _pPair pRetPair stubSymbol =
   do traceBundle bundle ("Handling PLT stub " ++ show stubSymbol)
 
      -- TODO!! Here we are just assuming the unknown function represented by the PLT stub

--- a/tests/AArch32TestMain.hs
+++ b/tests/AArch32TestMain.hs
@@ -17,7 +17,7 @@ main = do
         { testArchName = "aarch32"
         , testArchProxy = PA.SomeValidArch archData
         , testExpectEquivalenceFailure =
-            [ "stack-struct"
+            [ "stack-struct", "unequal/stack-struct"
             ]
         , testExpectSelfEquivalenceFailure = [ ]
         -- TODO: we should define a section name here and read its address

--- a/tests/PPC32TestMain.hs
+++ b/tests/PPC32TestMain.hs
@@ -17,7 +17,7 @@ main = do
         { testArchName = "ppc32"
         , testArchProxy = PA.SomeValidArch archData
         , testExpectEquivalenceFailure =
-            [ "stack-struct"
+            [ "stack-struct", "unequal/stack-struct"
             ]
         , testExpectSelfEquivalenceFailure =
             [

--- a/tests/PPCTestMain.hs
+++ b/tests/PPCTestMain.hs
@@ -17,7 +17,7 @@ main = do
         { testArchName = "ppc"
         , testArchProxy = PA.SomeValidArch archData
         , testExpectEquivalenceFailure =
-            [ "stack-struct"
+            [ "stack-struct", "unequal/stack-struct"
             ]
         , testExpectSelfEquivalenceFailure = []
         -- TODO: we should define a section name here and read its address

--- a/tests/TestBase.hs
+++ b/tests/TestBase.hs
@@ -141,7 +141,7 @@ doTest mwb cfg sv proxy@(PA.SomeValidArch {}) fp = do
       , PL.patchedPath = fp <.> "patched" <.> "exe"
       , PL.origHints = mempty
       , PL.patchedHints = mempty
-      , PL.verificationCfg = PC.defaultVerificationCfg
+      , PL.verificationCfg = PC.defaultVerificationCfg { PC.cfgFailureMode = PC.ThrowOnAnyFailure }
       , PL.logger =
           LJ.LogAction $ \e -> case e of
             PE.Warning err -> do


### PR DESCRIPTION
This  is several optimizations that use caching and some changes to traversal and heuristic ordering.
(depends on #318)


  * use the same equivalence domain for discoverPairs and widening
     - deduplicate discovered pair results
  * cache intermediate results in abstractOverVars
  * traverse all locations during each widening iteration
     -  avoids re-checking earlier locations repeatedly
  * fail early on any exception during testing
  * cache intermediate results when checking sequence equality

fixes #313