### PR TITLE
Generalize 'MemCellPred' over the predicate merge operation

### DIFF
--- a/pate.cabal
+++ b/pate.cabal
@@ -132,6 +132,7 @@ library
                        Pate.ExprMappable,
                        What4.ExprHelpers,
                        What4.PathCondition,
+                       What4.PredMap,
                        Data.Parameterized.SetF,
                        Pate.SimState,
                        Pate.Equivalence,

--- a/src/Pate/Equivalence/MemoryDomain.hs
+++ b/src/Pate/Equivalence/MemoryDomain.hs
@@ -27,8 +27,7 @@ module Pate.Equivalence.MemoryDomain (
   , dropFalseCells
   ) where
 
-import           Control.Monad ( forM, join )
-import qualified Data.Map as M
+import           Control.Monad ( forM )
 import           Data.Maybe (catMaybes)
 import           Data.Parameterized.Classes
 import           Data.Parameterized.Some ( Some(..) )
@@ -44,9 +43,7 @@ import qualified Data.Macaw.CFG as MM
 import qualified Pate.ExprMappable as PEM
 import qualified Pate.MemCell as PMC
 import qualified Pate.Memory.MemTrace as MT
-import qualified Pate.Parallel as Par
 import qualified Pate.Location as PL
-import qualified What4.ExprHelpers as WEH
 import qualified What4.PredMap as WPM
 
 ---------------------------------------------

--- a/src/Pate/ExprMappable.hs
+++ b/src/Pate/ExprMappable.hs
@@ -27,7 +27,6 @@ import           Control.Monad.Trans.Class ( lift )
 import           Data.Functor.Const
 import           Data.Parameterized.Some
 import qualified Data.Parameterized.Context as Ctx
-import           Data.Parameterized.HasRepr ( typeRepr )
 import qualified Lang.Crucible.LLVM.MemModel as CLM
 import qualified Lang.Crucible.Simulator as CS
 import qualified Lang.Crucible.Types as CT

--- a/src/Pate/ExprMappable.hs
+++ b/src/Pate/ExprMappable.hs
@@ -27,6 +27,7 @@ import           Control.Monad.Trans.Class ( lift )
 import           Data.Functor.Const
 import           Data.Parameterized.Some
 import qualified Data.Parameterized.Context as Ctx
+import           Data.Parameterized.HasRepr ( typeRepr )
 import qualified Lang.Crucible.LLVM.MemModel as CLM
 import qualified Lang.Crucible.Simulator as CS
 import qualified Lang.Crucible.Types as CT
@@ -35,6 +36,7 @@ import qualified What4.Partial as WP
 import qualified What4.Expr.Builder as W4B
 
 import qualified What4.ExprHelpers as WEH
+import qualified What4.PredMap as WPM
 import qualified Pate.Parallel as Par
 
 -- Expression binding
@@ -128,3 +130,6 @@ newtype SkipTransformation a = SkipTransformation { unSkip :: a }
 
 instance ExprMappable sym (SkipTransformation a) where
   mapExpr _ _ = return
+
+instance (Ord f, ExprMappable sym f) => ExprMappable sym (WPM.PredMap sym f k) where
+  mapExpr sym f pm = WPM.alter sym pm (\v p -> (,) <$> mapExpr sym f v <*> f p)

--- a/src/Pate/MemCell.hs
+++ b/src/Pate/MemCell.hs
@@ -10,22 +10,17 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE LambdaCase   #-}
+{-# LANGUAGE KindSignatures   #-}
 
 module Pate.MemCell (
     MemCell(..)
+  , viewCell
   , ppCell
   , setMemCellRegion
-  , MemCellPred(..)
-  , traverseWithCell
-  , witherCell
-  , mergeMemCellPred
-  , muxMemCellPred
+  , MemCellPred
   , inMemCellPred
-  , dropFalseCells
   , readMemCell
   , writeMemCell
-  , predFromList
-  , predToList
   ) where
 
 import           Control.Monad ( foldM, forM )
@@ -49,6 +44,7 @@ import qualified Prettyprinter as PP
 import qualified Pate.ExprMappable as PEM
 import qualified Pate.Memory.MemTrace as PMT
 import qualified What4.ExprHelpers as WEH
+import qualified What4.PredMap as WPM
 
 -- | A pointer with an attached width, representing the size of the "cell" in bytes.
 -- It represents a discrete read or write, used as the key when forming a 'Pate.Equivalence.MemPred'
@@ -63,6 +59,9 @@ data MemCell sym arch w where
     , cellWidth :: PNR.NatRepr w
     , cellEndian :: MM.Endianness
     } -> MemCell sym arch w
+
+viewCell :: Some (MemCell sym arch) -> (forall w. 1 <= w => MemCell sym arch w -> a) -> a
+viewCell (Some (mc@MemCell{})) f = f mc
 
 instance PC.TestEquality (WI.SymExpr sym) => PC.TestEquality (MemCell sym arch) where
   testEquality (MemCell (CLM.LLVMPointer reg1 off1) sz1 end1) (MemCell (CLM.LLVMPointer reg2 off2) sz2 end2)
@@ -88,102 +87,80 @@ instance PC.OrdF (WI.SymExpr sym) => Ord (MemCell sym arch w) where
 
 -- | Each 'MemCell' is associated with the predicate that says whether or not the
 -- described memory is contained in the 'Pate.Equivalence.MemoryDomain'.
-newtype MemCellPred sym arch = MemCellPred (Map.Map (Some (MemCell sym arch)) (WI.Pred sym))
+type MemCellPred sym arch (k :: WPM.PredOpK) = WPM.PredMap sym (Some (MemCell sym arch)) k
 
+{-
 traverseWithCell ::
-  forall sym arch m.
+  forall sym arch k m.
   Monad m =>
   WI.IsExprBuilder sym =>
-  MemCellPred sym arch ->
+  MemCellPred sym arch k ->
   (forall w. 1 <= w => MemCell sym arch w -> WI.Pred sym -> m (WI.Pred sym)) ->
-  m (MemCellPred sym arch)
+  m (MemCellPred sym arch k)
 traverseWithCell (MemCellPred memPred) f =
-  MemCellPred <$> Map.traverseWithKey (\(Some cell@MemCell{}) p -> f cell p) memPred
+  MemCellPred <$> WEH.traversePredMap memPred (\(Some cell@MemCell{}) p -> f cell p)
 
 
 -- | Traverse a 'MemCellPred', optionally dropping elements instead of updating them.
 witherCell ::
-  forall sym arch m.
+  forall sym arch k m.
   IO.MonadIO m =>
   WI.IsExprBuilder sym =>
   PC.OrdF (WI.SymExpr sym) =>
   sym ->
-  MemCellPred sym arch ->
+  MemCellPred sym arch k ->
   (forall w. 1 <= w => MemCell sym arch w -> WI.Pred sym -> m (Maybe (MemCell sym arch w, WI.Pred sym))) ->
-  m (MemCellPred sym arch)
+  m (MemCellPred sym arch k)
 witherCell sym (MemCellPred memPred)  f = do
-  es <- fmap catMaybes $ forM (Map.toList memPred) $ \(Some (cell@MemCell{}), p) -> do
+  es <- fmap catMaybes $ forM (WEH.predMapToList memPred) $ \(Some (cell@MemCell{}), p) -> do
     f cell p >>= \case
       Just (cell', p') -> return $ Just (Some cell', p')
       Nothing -> return Nothing
-  IO.liftIO $ predFromList sym es
+  IO.liftIO $ predFromList sym (WEH.predMapRepr memPred) es
 
 predFromList ::
   WI.IsExprBuilder sym =>
   PC.OrdF (WI.SymExpr sym) =>
   sym ->
+  WEH.PredMergeRepr k ->
   [(Some (MemCell sym arch), WI.Pred sym)] ->
-  IO (MemCellPred sym arch)
-predFromList sym l = do
-  -- NOTE: We can't just use Data.Map.fromList here because it will discard duplicate
-  -- entries
-  let maps = map (\(cell, p) -> MemCellPred $ Map.singleton cell p) l
-  foldM (mergeMemCellPred sym) (MemCellPred Map.empty) maps
+  IO (MemCellPred sym arch k)
+predFromList sym r l = MemCellPred <$> WEH.predMapFromList sym r l
 
 predToList ::
-  MemCellPred sym arch ->
+  MemCellPred sym arch k ->
   [(Some (MemCell sym arch), WI.Pred sym)]
-predToList (MemCellPred cells) = Map.toList cells
+predToList (MemCellPred cells) = WEH.predMapToList cells
 
 -- | Drop entries from the map which are concretely false.
 dropFalseCells ::
-  forall sym arch.
+  forall sym arch k.
   WI.IsExprBuilder sym =>
-  MemCellPred sym arch ->
-  MemCellPred sym arch
-dropFalseCells (MemCellPred cells) = MemCellPred $ Map.mapMaybe dropFalse cells
-  where
-    dropFalse ::
-      WI.Pred sym ->
-      Maybe (WI.Pred sym)
-    dropFalse p = case WI.asConstantPred p of
-      Just False -> Nothing
-      _ -> Just p
+  MemCellPred sym arch k ->
+  MemCellPred sym arch k
+dropFalseCells (MemCellPred cells) = MemCellPred $ WEH.dropUnit cells
 
 mergeMemCellPred ::
   WI.IsExprBuilder sym =>
   PC.OrdF (WI.SymExpr sym) =>
   sym ->
-  MemCellPred sym arch ->
-  MemCellPred sym arch ->
-  IO (MemCellPred sym arch)
-mergeMemCellPred sym (MemCellPred cells1) (MemCellPred cells2) = fmap MemCellPred $ do
-  MapM.mergeA
-    MapM.preserveMissing
-    MapM.preserveMissing
-    (MapM.zipWithAMatched (\_ p1 p2 -> WI.orPred sym p1 p2))
-    cells1
-    cells2
+  MemCellPred sym arch k ->
+  MemCellPred sym arch k ->
+  IO (MemCellPred sym arch k)
+mergeMemCellPred sym (MemCellPred cells1) (MemCellPred cells2) = fmap MemCellPred $
+  WEH.mergePredMaps sym cells1 cells2
 
 muxMemCellPred ::
   WI.IsExprBuilder sym =>
   PC.OrdF (WI.SymExpr sym) =>
   sym ->
   WI.Pred sym ->
-  MemCellPred sym arch ->
-  MemCellPred sym arch ->
-  IO (MemCellPred sym arch)
-muxMemCellPred sym p (MemCellPred cellsT) (MemCellPred cellsF) = case WI.asConstantPred p of
-  Just True -> return $ MemCellPred cellsT
-  Just False -> return $ MemCellPred cellsF
-  _ -> fmap MemCellPred $ do
-    notp <- WI.notPred sym p
-    MapM.mergeA
-      (MapM.traverseMissing (\_ pT -> WI.andPred sym pT p))
-      (MapM.traverseMissing (\_ pF -> WI.andPred sym pF notp))
-      (MapM.zipWithAMatched (\_ p1 p2 -> WI.baseTypeIte sym p p1 p2))
-      cellsT
-      cellsF
+  MemCellPred sym arch k ->
+  MemCellPred sym arch k ->
+  IO (MemCellPred sym arch k)
+muxMemCellPred sym p (MemCellPred cellsT) (MemCellPred cellsF) =
+  fmap MemCellPred $ WEH.muxPredMaps sym p cellsT cellsF
+-}
 
 -- | Check if a 'MemCell' is in the given 'MemCellPred'. This is true
 -- if and only if:
@@ -193,17 +170,17 @@ muxMemCellPred sym p (MemCellPred cellsT) (MemCellPred cellsF) = case WI.asConst
 -- (i.e. the 'w' bytes starting from the base address). The exact cell must be
 -- present in the 'MemCellPred' for the result of this function to be true.
 inMemCellPred ::
-  forall sym arch w.
+  forall sym arch w k.
   WI.IsExprBuilder sym =>
   PC.OrdF (WI.SymExpr sym) =>
   sym ->
   MemCell sym arch w ->
-  MemCellPred sym arch ->
+  MemCellPred sym arch WPM.PredDisjT ->
   IO (WI.Pred sym)
-inMemCellPred sym cell (MemCellPred cells) =
-  case Map.lookup (Some cell) cells of
-    Just cond | Just True <- WI.asConstantPred cond -> return $ WI.truePred sym
-    _ -> go (WI.falsePred sym) (Map.toList cells)
+inMemCellPred sym cell cells =
+  case WI.asConstantPred (WPM.lookup sym (Some cell) cells) of
+    Just True -> return $ WI.truePred sym
+    _ -> go (WI.falsePred sym) (WPM.toList cells)
   where
     go :: WI.Pred sym -> [(Some (MemCell sym arch), WI.Pred sym)] -> IO (WI.Pred sym)
     go p ((Some cell', cond) : cells') = case WI.testEquality (cellWidth cell) (cellWidth cell') of
@@ -257,16 +234,6 @@ instance PEM.ExprMappable sym (MemCell sym arch w) where
   mapExpr sym f (MemCell ptr w end) = do
     ptr' <- WEH.mapExprPtr sym f ptr
     return $ MemCell ptr' w end
-
-instance PEM.ExprMappable sym (MemCellPred sym arch) where
-  mapExpr sym f (MemCellPred memPred) = do
-    let (ks, vs) = unzip $ Map.toAscList memPred
-    ks' <- PEM.mapExpr sym f ks
-    vs' <- PEM.mapExpr sym f (map (PEM.ToExprMappable @sym) vs)
-    let vs'' = map PEM.unEM vs'
-    case ks == ks' of
-      True -> return $ MemCellPred (Map.fromAscList (zip ks vs''))
-      False -> IO.liftIO $ predFromList sym (zip ks' vs'')
 
 ppCell :: (WI.IsSymExprBuilder sym) => MemCell sym arch w -> PP.Doc a
 ppCell cell =

--- a/src/Pate/Proof/CounterExample.hs
+++ b/src/Pate/Proof/CounterExample.hs
@@ -268,13 +268,13 @@ getSatIO = withValid $ do
 -- excluding conditions which are necessarily true).
 getPathCondition ::
   forall sym arch v.
-  PE.StateCondition sym arch v ->
+  PE.StatePostCondition sym arch v ->
   PS.SimOutput sym arch v PB.Original ->
   PS.SimOutput sym arch v PB.Patched ->
   SymGroundEvalFn sym ->
   EquivM sym arch (W4.Pred sym)
 getPathCondition stCond outO outP fn = withSym $ \sym -> do
-  regCond <- getRegPathCondition (PE.stRegCond stCond) fn
+  regCond <- getRegPathCondition (PE.stRegPostCond stCond) fn
   withAssumption regCond $ do
     memOCond <- getGenPathCondition fn (PS.simOutMem outO)
     withAssumption memOCond $ do

--- a/src/Pate/Verification/AbstractDomain.hs
+++ b/src/Pate/Verification/AbstractDomain.hs
@@ -532,7 +532,7 @@ absDomainToPrecond ::
   IO (PS.AssumptionSet sym v)
 absDomainToPrecond sym eqCtx bundle d = do
   eqInputs <- PE.getPredomain sym bundle eqCtx (absDomEq d)
-  eqInputsPred <- PE.preCondAssumption sym (PS.simInO bundle) (PS.simInP bundle) eqInputs
+  eqInputsPred <- PE.preCondAssumption sym (PS.simInO bundle) (PS.simInP bundle) eqCtx eqInputs
   valsPred <- do
     (predO, predP) <- PPa.forBinsC $ \get -> do
       let absBlockState = PS.simInAbsState (get $ PS.simIn bundle)

--- a/src/Pate/Verification/Widening.hs
+++ b/src/Pate/Verification/Widening.hs
@@ -32,8 +32,6 @@ import           Data.List (foldl')
 import           Data.Parameterized.Classes()
 import           Data.Parameterized.NatRepr
 import           Data.Parameterized.Some
-import qualified Data.Parameterized.Map as MapF
-import qualified Data.Parameterized.SetF as SetF
 
 import qualified What4.Interface as W4
 import qualified What4.Expr.Builder as W4B

--- a/src/What4/ExprHelpers.hs
+++ b/src/What4/ExprHelpers.hs
@@ -91,6 +91,8 @@ import qualified Data.HashTable.ST.Basic as H
 import           Data.Word (Word64)
 import           Data.Set (Set)
 import qualified Data.Set as S
+import qualified Data.Map as Map
+import qualified Data.Map.Merge.Strict as MapM
 import           Data.List ( foldl' )
 import           Data.List.NonEmpty (NonEmpty(..))
 import           Data.Proxy (Proxy(..))

--- a/src/What4/ExprHelpers.hs
+++ b/src/What4/ExprHelpers.hs
@@ -91,8 +91,6 @@ import qualified Data.HashTable.ST.Basic as H
 import           Data.Word (Word64)
 import           Data.Set (Set)
 import qualified Data.Set as S
-import qualified Data.Map as Map
-import qualified Data.Map.Merge.Strict as MapM
 import           Data.List ( foldl' )
 import           Data.List.NonEmpty (NonEmpty(..))
 import           Data.Proxy (Proxy(..))

--- a/src/What4/PredMap.hs
+++ b/src/What4/PredMap.hs
@@ -1,0 +1,251 @@
+{-|
+Module           : What4.PredMap
+Copyright        : (c) Galois, Inc 2020
+Maintainer       : Daniel Matichuk <dmatichuk@galois.com>
+
+Map with What4 predicates in the range, indexed by the default predicate merge operation
+(conjunction or disjuction) to use in the case of key clashes.
+-}
+
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module What4.PredMap (
+    type PredOpK
+  , type PredDisjT
+  , type PredConjT
+  , PredMap
+  , PredOpRepr(..)
+  , applyPredOp
+  , empty
+  , singleton
+  , merge
+  , dropUnit
+  , traverse
+  , alter
+  , alter'
+  , lookup
+  , toList
+  , fromList
+  , mux
+  , predOpUnit
+  , isPredOpUnit
+  ) where
+
+import           Prelude hiding ( lookup, traverse )
+
+import qualified Control.Monad.IO.Class as IO
+import           Control.Monad ( foldM )
+
+import           Data.Proxy (Proxy(..))
+import qualified Data.Map as Map
+import qualified Data.Map.Merge.Strict as MapM
+
+import           Data.Parameterized.Classes
+import           Data.Parameterized.HasRepr
+import           Data.Parameterized.WithRepr
+
+import qualified What4.Interface as W4
+
+data PredOpK =
+    PredConjT
+  | PredDisjT
+
+type PredConjT = 'PredConjT
+type PredDisjT = 'PredDisjT
+
+data PredMap sym f (k :: PredOpK) where
+  PredMap :: { predOpRepr :: PredOpRepr k
+             , predMap :: Map.Map f (W4.Pred sym)
+             } -> PredMap sym f k
+
+data PredOpRepr k where
+  PredConjRepr :: PredOpRepr PredConjT
+  PredDisjRepr :: PredOpRepr PredDisjT
+
+instance HasRepr (PredMap sym f) PredOpRepr where
+  typeRepr pm = predOpRepr pm
+
+instance KnownRepr PredOpRepr 'PredConjT where
+  knownRepr = PredConjRepr
+
+instance KnownRepr PredOpRepr 'PredDisjT where
+  knownRepr = PredDisjRepr
+
+instance IsRepr PredOpRepr
+
+empty ::
+  PredOpRepr k -> PredMap sym f k
+empty r = PredMap r Map.empty
+
+singleton ::
+  Ord f =>
+  PredOpRepr k ->
+  f ->
+  W4.Pred sym ->
+  PredMap sym f k
+singleton r f p = PredMap r (Map.singleton f p)
+
+applyPredOp ::
+  IO.MonadIO m =>
+  W4.IsExprBuilder sym =>
+  sym ->
+  PredOpRepr k ->
+  W4.Pred sym ->
+  W4.Pred sym ->
+  m (W4.Pred sym)
+applyPredOp sym PredConjRepr p1 p2 = IO.liftIO $ W4.andPred sym p1 p2
+applyPredOp sym PredDisjRepr p1 p2 = IO.liftIO $ W4.orPred sym p1 p2
+
+predOpUnit ::
+  W4.IsExprBuilder sym =>
+  sym ->
+  PredOpRepr k ->
+  W4.Pred sym
+predOpUnit sym PredConjRepr = W4.truePred sym
+predOpUnit sym PredDisjRepr = W4.falsePred sym
+
+isPredOpUnit ::
+  W4.IsExprBuilder sym =>
+  f sym ->
+  PredOpRepr k ->
+  W4.Pred sym ->
+  Bool
+isPredOpUnit _ r p = case (W4.asConstantPred p, r) of
+  (Just True, PredConjRepr) -> True
+  (Just False, PredDisjRepr) -> True
+  _ -> False
+
+merge ::
+  IO.MonadIO m =>
+  W4.IsExprBuilder sym =>
+  Ord f =>
+  sym ->
+  PredMap sym f k ->
+  PredMap sym f k ->
+  m (PredMap sym f k)
+merge sym pm1 pm2 = PredMap <$> pure (typeRepr pm1) <*>
+    MapM.mergeA
+      MapM.preserveMissing
+      MapM.preserveMissing
+      (MapM.zipWithAMatched (\_ p1' p2' -> applyPredOp sym (typeRepr pm1) p1' p2'))
+      (predMap pm1)
+      (predMap pm2)
+
+mux ::
+  IO.MonadIO m =>
+  W4.IsExprBuilder sym =>
+  Ord f =>
+  sym ->
+  W4.Pred sym ->
+  PredMap sym f k ->
+  PredMap sym f k ->
+  m (PredMap sym f k)
+mux sym p pmT pmF = case W4.asConstantPred p of
+  Just True -> return pmT
+  Just False -> return pmF
+  _ -> PredMap <$> pure (typeRepr pmT) <*>
+    (IO.liftIO $ MapM.mergeA
+      (MapM.traverseMissing (\_ pT -> W4.baseTypeIte sym p pT (predOpUnit sym (typeRepr pmT))))
+      (MapM.traverseMissing (\_ pF -> W4.baseTypeIte sym p (predOpUnit sym (typeRepr pmT)) pF))
+      (MapM.zipWithAMatched (\_ pT pF -> W4.baseTypeIte sym p pT pF))
+      (predMap pmT)
+      (predMap pmF))
+
+-- | Remove entries from the map that point to the unit element of the
+-- underlying predicate operation.
+-- This preserves the invariant that 'lookup k m' == 'lookup k (dropUnit m)' for
+-- any key 'k'.
+dropUnit ::
+  forall sym f k.
+  W4.IsExprBuilder sym =>
+  PredMap sym f k ->
+  PredMap sym f k
+dropUnit pm  = PredMap (typeRepr pm) $
+  Map.mapMaybe (\p -> case isPredOpUnit (Proxy @sym) (typeRepr pm) p of
+                        True -> Nothing
+                        _ -> Just p) (predMap pm)
+
+-- | Traverse and modify the predicate associated with each key.
+traverse ::
+  Applicative m =>
+  PredMap sym f k ->
+  (f -> W4.Pred sym -> m (W4.Pred sym)) ->
+  m (PredMap sym f k)
+traverse pm f = PredMap <$> pure (typeRepr pm) <*> Map.traverseWithKey f (predMap pm)
+
+-- | Alter the key-predicate pairs in a 'PredMap'.
+-- When any keys are modified, the map is safely rebuilt according
+-- to the underlying predicate operation in the case of duplicate entries
+-- in the resulting map.
+alter ::
+  IO.MonadIO m =>
+  W4.IsExprBuilder sym =>
+  Ord f =>
+  sym ->
+  PredMap sym f k ->
+  (f -> W4.Pred sym -> m (f, W4.Pred sym)) ->
+  m (PredMap sym f k)
+alter sym pm f = do
+  let (ks, vs) = unzip $ Map.toAscList (predMap pm)
+  (ks', vs') <- unzip <$> mapM (\(k, p) -> f k p) (zip ks vs)
+  case ks == ks' of
+    -- if the keys are unmodified, we can just treat this like a normal traversal
+    True -> return $ PredMap (typeRepr pm) (Map.fromAscList (zip ks' vs'))
+    -- otherwise we have to use the 'fromList' defined here which accounts
+    -- for possible duplicate entries
+    False -> fromList sym (typeRepr pm) (zip ks' vs')
+
+-- | Alter the key-predicate pairs in a 'PredMap', rebuilding
+-- the map safely according to the underlying predicate operation
+-- in the case of duplicate entries in the resulting map.
+alter' ::
+  IO.MonadIO m =>
+  W4.IsExprBuilder sym =>
+  Ord g =>
+  sym ->
+  PredMap sym f k ->
+  (f -> W4.Pred sym -> m (g, W4.Pred sym)) ->
+  m (PredMap sym g k)
+alter' sym pm f = do
+  pm' <- mapM (\(k, p) -> f k p) (Map.toList (predMap pm))
+  fromList sym (typeRepr pm) pm'
+
+-- | Lookup an entry in the underlying map, returning the unit entry of
+-- the predicate operation for the map if the entry is not present
+lookup ::
+  forall sym f k.
+  W4.IsExprBuilder sym =>
+  Ord f =>
+  sym ->
+  f ->
+  PredMap sym f k ->
+  W4.Pred sym
+lookup sym f pm = case Map.lookup f (predMap pm) of
+  Just p -> p
+  Nothing -> predOpUnit sym (typeRepr pm)
+
+toList ::
+  PredMap sym f k ->
+  [(f, W4.Pred sym)]
+toList pm = Map.toList (predMap pm)
+
+-- | Convert a list of key-predicate pairs into a 'PredMap', merging duplicate
+-- entries according to the corresponding predicate operation indicated by
+-- the given 'PredOpRepr'
+fromList ::
+  forall f m k sym.
+  Ord f =>
+  IO.MonadIO m =>
+  W4.IsExprBuilder sym =>
+  sym ->
+  PredOpRepr k ->
+  [(f, W4.Pred sym)] ->
+  m (PredMap sym f k)
+fromList sym r l = foldM (\ms (f,p) -> merge sym (singleton r f p) ms) (empty r) l

--- a/tests/AArch32TestMain.hs
+++ b/tests/AArch32TestMain.hs
@@ -19,7 +19,7 @@ main = do
         , testExpectEquivalenceFailure =
             [ "stack-struct", "unequal/stack-struct"
             ]
-        , testExpectSelfEquivalenceFailure = ["stack-struct"]
+        , testExpectSelfEquivalenceFailure = []
         -- TODO: we should define a section name here and read its address
         -- from the ELF
         -- see: https://github.com/GaloisInc/pate/issues/294

--- a/tests/PPC32TestMain.hs
+++ b/tests/PPC32TestMain.hs
@@ -20,7 +20,7 @@ main = do
             [ "stack-struct", "unequal/stack-struct"
             ]
         , testExpectSelfEquivalenceFailure =
-            [ "stack-struct"
+            [
             ]
         -- TODO: we should define a section name here and read its address
         -- from the ELF

--- a/tests/PPCTestMain.hs
+++ b/tests/PPCTestMain.hs
@@ -19,7 +19,7 @@ main = do
         , testExpectEquivalenceFailure =
             [ "stack-struct", "unequal/stack-struct"
             ]
-        , testExpectSelfEquivalenceFailure = ["stack-struct"]
+        , testExpectSelfEquivalenceFailure = []
         -- TODO: we should define a section name here and read its address
         -- from the ELF
         -- see: https://github.com/GaloisInc/pate/issues/294


### PR DESCRIPTION
Fixes #322 by introducing 'What4.PredMap': a map from keys to predicates, which is parameterized by a merge operation to perform in the case of key clashes, and clarifying that `MemoryDomain` should use disjunction, while `StateCondition` should use conjunction.