### PR TITLE
generalize PatchPair to support singletons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 cabal.project.local
 dist-newstyle/
+dist-profile/
 *.i
 /docs/user-manual/auto/
 /docs/user-manual/user-manual.aux
@@ -7,3 +8,10 @@ dist-newstyle/
 /docs/user-manual/user-manual.fls
 /docs/user-manual/user-manual.log
 /docs/user-manual/user-manual.toc
+*.cfg
+*.o
+*.s
+*.dump
+*.local
+*.log
+*.hi

--- a/arch/Pate/PPC.hs
+++ b/arch/Pate/PPC.hs
@@ -28,7 +28,6 @@ where
 import           Control.Lens ( (^.), (^?) )
 import qualified Control.Lens as L
 import qualified Control.Monad.Catch as CMC
-import           Control.Monad.Trans ( lift )
 import qualified Data.BitVector.Sized as BVS
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ElfEdit.Prim as EEP

--- a/arch/Pate/PPC.hs
+++ b/arch/Pate/PPC.hs
@@ -104,7 +104,7 @@ getCurrentTOC
   -> IO (W.W 64)
 getCurrentTOC ctx binRepr = PPa.runPatchPairT $ do
   ctx' <- PPa.get binRepr (PMC.binCtxs ctx)
-  blks <- lift $ PD.getBlocks' ctx (ctx ^. PMC.currentFunc)
+  blks <- PD.getBlocks' ctx (ctx ^. PMC.currentFunc)
   PE.Blocks _ _ (pblk:_) <- PPa.get binRepr blks
   let
     toc = TOC.getTOC (PMC.binary ctx')

--- a/arch/Pate/PPC.hs
+++ b/arch/Pate/PPC.hs
@@ -102,10 +102,10 @@ getCurrentTOC
   => PMC.EquivalenceContext sym PPC.PPC64
   -> PB.WhichBinaryRepr bin
   -> IO (W.W 64)
-getCurrentTOC ctx binRepr = PPa.withPatchPairT (PMC.binCtxs ctx) $ do
+getCurrentTOC ctx binRepr = PPa.runPatchPairT $ do
+  ctx' <- PPa.get binRepr (PMC.binCtxs ctx)
   blks <- lift $ PD.getBlocks' ctx (ctx ^. PMC.currentFunc)
   PE.Blocks _ _ (pblk:_) <- PPa.get binRepr blks
-  ctx' <- PPa.get binRepr (PMC.binCtxs ctx)
   let
     toc = TOC.getTOC (PMC.binary ctx')
     addr = MD.pblockAddr pblk

--- a/src/Pate/Abort.hs
+++ b/src/Pate/Abort.hs
@@ -60,7 +60,11 @@ proveAbortValid ::
   WI.Pred sym ->
   EquivM sym arch Bool
 proveAbortValid bundle condEq = withSym $ \sym -> do
-  oAbort <- isAbortedStatePred (PPa.pOriginal . PSS.simOut $ bundle)
+  outO <- case PSS.simOut bundle of
+    PPa.PatchPair outO _ -> return outO
+    PPa.PatchPairOriginal outO -> return outO
+    _ -> PPa.handleSingletonStub
+  oAbort <- isAbortedStatePred outO
   heuristicTimeout <- CMR.asks (PC.cfgHeuristicTimeout . envConfig)
   traceBundle bundle "Checking conditional equivalence validity"
   -- assuming conditional equivalence does not hold (i.e. the programs may diverge)

--- a/src/Pate/AssumptionSet.hs
+++ b/src/Pate/AssumptionSet.hs
@@ -17,6 +17,7 @@ module Pate.AssumptionSet (
   , augment
   , fromExprBindings
   , exprBinding
+  , bindExprPair
   , natBinding
   , ptrBinding
   , macawRegBinding
@@ -52,6 +53,7 @@ import           Data.Parameterized.SetF ( SetF )
 import qualified Data.Parameterized.SetF as SetF
 import qualified Pate.SimulatorRegisters as PSR
 import           Pate.Panic
+import qualified Pate.PatchPair as PPa
 import qualified What4.ExprHelpers as WEH
 import           What4.ExprHelpers ( ExprSet, VarBindCache, ExprBindings, ppExprSet )
 import qualified Pate.ExprMappable as PEM
@@ -171,6 +173,16 @@ exprBinding ::
 exprBinding eSrc eTgt = case testEquality eSrc eTgt of
   Just Refl -> mempty
   _ -> mempty { asmBinds = (MapF.singleton eSrc (SetF.singleton eTgt)) }
+
+-- | Equates an original and patched assumption (binds the original to the patched)
+--   Has no effect for singleton 'PatchPair' values
+bindExprPair ::
+  forall sym tp.
+  W4.IsSymExprBuilder sym =>
+  PPa.PatchPairC (W4.SymExpr sym tp) ->
+  AssumptionSet sym
+bindExprPair (PPa.PatchPairC src tgt) = exprBinding src tgt
+bindExprPair _ = mempty
 
 natBinding ::
   forall sym.

--- a/src/Pate/Binary.hs
+++ b/src/Pate/Binary.hs
@@ -81,6 +81,9 @@ instance Show (WhichBinaryRepr bin) where
   show OriginalRepr = "Original"
   show PatchedRepr = "Patched"
 
+instance PP.Pretty (WhichBinaryRepr bin) where
+  pretty = PP.viaShow
+
 instance KnownRepr WhichBinaryRepr Original where
   knownRepr = OriginalRepr
 

--- a/src/Pate/Block.hs
+++ b/src/Pate/Block.hs
@@ -302,7 +302,9 @@ type BlockPair arch = PPa.PatchPair (ConcreteBlock arch)
 type FunPair arch = PPa.PatchPair (FunctionEntry arch)
 
 -- | Returns 'True' if the equated function pair (specified by address) matches
--- the current call target
+-- the current call target.
+--   For singleton 'BlockPair' values this always returns false, since there
+--   it cannot match an equated function pair.
 matchEquatedAddress
   :: BlockPair arch
   -- ^ Addresses of the call targets in the original and patched binaries (in

--- a/src/Pate/Block.hs
+++ b/src/Pate/Block.hs
@@ -310,11 +310,11 @@ matchEquatedAddress
   -> (PA.ConcreteAddress arch, PA.ConcreteAddress arch)
   -- ^ Equated function pair
   -> Bool
-matchEquatedAddress pPair (origAddr, patchedAddr) =
-  and [ origAddr == concreteAddress (PPa.pOriginal pPair)
-      , patchedAddr == concreteAddress (PPa.pPatched pPair)
+matchEquatedAddress (PPa.PatchPair blkO blkP) (origAddr, patchedAddr) =
+  and [ origAddr == concreteAddress blkO
+      , patchedAddr == concreteAddress blkP
       ]
-
+matchEquatedAddress _ _ = False
 
 -- FIXME: put this somewhere more sensible
 

--- a/src/Pate/Discovery.hs
+++ b/src/Pate/Discovery.hs
@@ -190,10 +190,9 @@ matchingExits ::
   SimBundle sym arch v ->
   MCS.MacawBlockEndCase ->
   EquivM sym arch (WI.Pred sym)
-matchingExits bundle ecase = withSym $ \sym -> do
-  case1 <- liftIO $ MCS.isBlockEndCase (Proxy @arch) sym (PSS.simOutBlockEnd $ PSS.simOutO bundle) ecase
-  case2 <- liftIO $ MCS.isBlockEndCase (Proxy @arch) sym (PSS.simOutBlockEnd $ PSS.simOutP bundle) ecase
-  liftIO $ WI.andPred sym case1 case2
+matchingExits bundle ecase = withSym $ \sym -> andPatchPred $ \bin ->  do
+  blkend <- PSS.simOutBlockEnd <$> PPa.get bin (PSS.simOut bundle)
+  liftIO $ MCS.isBlockEndCase (Proxy @arch) sym blkend ecase
 
 -- | True when both the patched and original program necessarily end with
 -- a call to the same function, assuming exact initial equivalence.
@@ -202,19 +201,20 @@ isMatchingCall ::
   SimBundle sym arch v ->
   EquivM sym arch Bool
 isMatchingCall bundle = withSym $ \sym -> do
-  eqIPs <- liftIO $ MT.llvmPtrEq sym (PSR.macawRegValue ipO) (PSR.macawRegValue ipP)
+  eqIPs <- PPa.defaultPair (return $ WI.truePred sym) (PSS.simOut bundle) $ \outO outP -> do
+    let
+      ipO = (PSS.simOutRegs outO) ^. MC.curIP
+      ipP = (PSS.simOutRegs outP) ^. MC.curIP
+    liftIO $ MT.llvmPtrEq sym (PSR.macawRegValue ipO) (PSR.macawRegValue ipP)
   goalTimeout <- CMR.asks (PC.cfgGoalTimeout . envConfig)
   -- TODO: Why are some of the calls being classified as Arch exits?
   isCall <- matchingExits bundle MCS.MacawBlockEndCall
   isArch <- matchingExits bundle MCS.MacawBlockEndArch
   isExpectedExit <- liftIO $ WI.orPred sym isArch isCall
   goal <- liftIO $ WI.andPred sym eqIPs isExpectedExit
-  asm <- exactEquivalence (PSS.simInO bundle) (PSS.simInP bundle)
+  asm <- exactEquivalence (PSS.simIn bundle)
   withAssumption asm $
     isPredTrue' goalTimeout goal
-  where
-    ipO = (PSS.simOutRegs $ PSS.simOutO bundle) ^. MC.curIP
-    ipP = (PSS.simOutRegs $ PSS.simOutP bundle) ^. MC.curIP
 
 -- | True for a pair of original and patched block targets that represent a valid pair of
 -- jumps
@@ -230,27 +230,27 @@ compatibleTargets blkt1 blkt2 = (PB.targetEndCase blkt1 == PB.targetEndCase blkt
     _ -> False
 
 exactEquivalence ::
-  PSS.SimInput sym arch v PB.Original ->
-  PSS.SimInput sym arch v PB.Patched ->
+  PPa.PatchPair (PSS.SimInput sym arch v) ->
   EquivM sym arch (WI.Pred sym)
-exactEquivalence inO inP = withSym $ \sym -> do
-  eqCtx <- equivalenceContext
-  regsEqs <- liftIO $ PRt.zipWithRegStatesM (PSS.simInRegs inO) (PSS.simInRegs inP) $ \r v1 v2 ->
-    Const <$> PEq.registerValuesEqual sym eqCtx r v1 v2
+exactEquivalence input = withSym $ \sym ->
+  PPa.defaultPair (return $ WI.truePred sym) input $ \inO inP -> do
+    eqCtx <- equivalenceContext
+    regsEqs <- liftIO $ PRt.zipWithRegStatesM (PSS.simInRegs inO) (PSS.simInRegs inP) $ \r v1 v2 ->
+      Const <$> PEq.registerValuesEqual sym eqCtx r v1 v2
 
-  regsEq <- liftIO $ WEH.allPreds sym (map snd $ PRt.assocs regsEqs)
-  heuristicTimeout <- CMR.asks (PC.cfgHeuristicTimeout . envConfig)
-  isPredSat heuristicTimeout regsEq >>= \case
-    True -> return ()
-    False -> CME.fail "exactEquivalence: regsEq: assumed false"
+    regsEq <- liftIO $ WEH.allPreds sym (map snd $ PRt.assocs regsEqs)
+    heuristicTimeout <- CMR.asks (PC.cfgHeuristicTimeout . envConfig)
+    isPredSat heuristicTimeout regsEq >>= \case
+      True -> return ()
+      False -> CME.fail "exactEquivalence: regsEq: assumed false"
 
-  memEq <- liftIO $ MT.memEqExact sym (MT.memState $ PSS.simInMem inO) (MT.memState $ PSS.simInMem inP)
+    memEq <- liftIO $ MT.memEqExact sym (MT.memState $ PSS.simInMem inO) (MT.memState $ PSS.simInMem inP)
 
-  isPredSat heuristicTimeout memEq >>= \case
-    True -> return ()
-    False -> CME.fail "exactEquivalence: memEq: assumed false"
+    isPredSat heuristicTimeout memEq >>= \case
+      True -> return ()
+      False -> CME.fail "exactEquivalence: memEq: assumed false"
 
-  liftIO $ WI.andPred sym regsEq memEq
+    liftIO $ WI.andPred sym regsEq memEq
 
 matchesBlockTargetOne ::
   forall sym arch bin v.
@@ -671,41 +671,36 @@ runDiscovery mCFGDir repr extraSyms elf hints pd = do
              let addr = PA.segOffToAddr segoff
              in Map.insert addr fd m
 
+getBlocksSingle
+  :: forall bin arch sym m
+   . (CMC.MonadThrow m, PPa.PatchPairM m, MS.SymArchConstraints arch, Typeable arch, HasCallStack, MonadIO m, PB.KnownBinary bin)
+  => PMC.EquivalenceContext sym arch
+  -> PB.ConcreteBlock arch bin
+  -> m (PE.Blocks arch bin)
+getBlocksSingle ctx blk = do
+  let (bin :: PB.WhichBinaryRepr bin) = WI.knownRepr
+  ctx' <- PPa.get bin (PMC.binCtxs ctx)
+  (liftIO $ lookupBlocks' ctx' blk) >>= \case
+    Right (PDP.ParsedBlocks pbs) -> return $! PE.Blocks PC.knownRepr blk pbs
+    Left err -> CMC.throwM err
+
 getBlocks'
-  :: (CMC.MonadThrow m, MS.SymArchConstraints arch, Typeable arch, HasCallStack, MonadIO m)
+  :: (CMC.MonadThrow m, PPa.PatchPairM m, MS.SymArchConstraints arch, Typeable arch, HasCallStack, MonadIO m)
   => PMC.EquivalenceContext sym arch
   -> PB.BlockPair arch
   -> m (PE.BlocksPair arch)
-getBlocks' ctx pPair = do
-  bs1 <- liftIO $ lookupBlocks' ctxO blkO
-  bs2 <- liftIO $ lookupBlocks' ctxP blkP
-  case (bs1, bs2) of
-    (Right (PDP.ParsedBlocks opbs), Right (PDP.ParsedBlocks ppbs)) -> do
-      let oBlocks = PE.Blocks PC.knownRepr blkO opbs
-      let pBlocks = PE.Blocks PC.knownRepr blkP ppbs
-      return $! PPa.PatchPair oBlocks pBlocks
-    (Left err, _) -> CMC.throwM err
-    (_, Left err) -> CMC.throwM err
-  where
-    binCtxs = PMC.binCtxs ctx
-    ctxO = PPa.pOriginal binCtxs
-    ctxP = PPa.pPatched binCtxs
-    blkO = PPa.pOriginal pPair
-    blkP = PPa.pPatched pPair
+getBlocks' ctx pPair = PPa.forBins $ \bin -> do
+  blk <- PPa.get bin pPair
+  getBlocksSingle ctx blk
 
 getBlocks ::
   HasCallStack =>
   PB.BlockPair arch ->
   EquivM sym arch (PE.BlocksPair arch)
-getBlocks pPair = do
-  PDP.ParsedBlocks opbs <- lookupBlocks blkO
-  let oBlocks = PE.Blocks PC.knownRepr blkO opbs
-  PDP.ParsedBlocks ppbs <- lookupBlocks blkP
-  let pBlocks = PE.Blocks PC.knownRepr blkP ppbs
-  return $ PPa.PatchPair oBlocks pBlocks
-  where
-    blkO = PPa.pOriginal pPair
-    blkP = PPa.pPatched pPair
+getBlocks pPair = PPa.forBins $ \bin -> do
+  blk <- PPa.get bin pPair
+  PDP.ParsedBlocks pbs <- lookupBlocks blk
+  return $! PE.Blocks PC.knownRepr blk pbs
 
 lookupBlocks'
   :: (MS.SymArchConstraints arch, Typeable arch, HasCallStack, PB.KnownBinary bin)

--- a/src/Pate/Discovery.hs
+++ b/src/Pate/Discovery.hs
@@ -190,7 +190,7 @@ matchingExits ::
   SimBundle sym arch v ->
   MCS.MacawBlockEndCase ->
   EquivM sym arch (WI.Pred sym)
-matchingExits bundle ecase = withSym $ \sym -> andPatchPred $ \bin ->  do
+matchingExits bundle ecase = withSym $ \sym -> PPa.joinPatchPred (\x y -> liftIO $ WI.andPred sym x y) $ \bin ->  do
   blkend <- PSS.simOutBlockEnd <$> PPa.get bin (PSS.simOut bundle)
   liftIO $ MCS.isBlockEndCase (Proxy @arch) sym blkend ecase
 

--- a/src/Pate/Equivalence/Error.hs
+++ b/src/Pate/Equivalence/Error.hs
@@ -14,6 +14,7 @@ module Pate.Equivalence.Error (
   , InequivalenceReason(..)
   , EquivalenceError(..)
   , SimpResult(..)
+  , SomeInnerError(..)
   , equivalenceError
   , equivalenceErrorFor
   , isRecoverable
@@ -118,6 +119,7 @@ data InnerEquivalenceError arch
   | SkippedInequivalentBlocks (PB.BlockPair arch)
   | SymbolicExecutionError String
   | UnsatisfiableEquivalenceCondition (SomeExpr W4.BaseBoolType)
+  | InconsistentPatchPairAccess
   | forall tp. FailedToGroundExpr (SomeExpr tp)
 
 data SomeExpr tp = forall sym. W4.IsExpr (W4.SymExpr sym) => SomeExpr (W4.SymExpr sym tp)
@@ -192,7 +194,6 @@ data LoadError where
   BSIParseError :: FilePath -> PHB.JSONError -> LoadError
   ElfParseError :: DEE.ElfParseError -> LoadError
   ConfigError :: String -> LoadError
-  InconsistentPatchPairAccess :: LoadError
 deriving instance Show LoadError
 
 

--- a/src/Pate/Equivalence/Error.hs
+++ b/src/Pate/Equivalence/Error.hs
@@ -192,6 +192,7 @@ data LoadError where
   BSIParseError :: FilePath -> PHB.JSONError -> LoadError
   ElfParseError :: DEE.ElfParseError -> LoadError
   ConfigError :: String -> LoadError
+  InconsistentPatchPairAccess :: LoadError
 deriving instance Show LoadError
 
 

--- a/src/Pate/Event.hs
+++ b/src/Pate/Event.hs
@@ -114,7 +114,7 @@ data Event arch where
   --
   -- This is useful for debugging, but probably should not be shown/collected
   -- unless explicitly asked for.
-  ProofTraceEvent :: GS.CallStack -> PA.ConcreteAddress arch -> PA.ConcreteAddress arch -> T.Text -> TM.NominalDiffTime -> Event arch
+  ProofTraceEvent :: GS.CallStack -> PPa.PatchPairC (PA.ConcreteAddress arch) -> T.Text -> TM.NominalDiffTime -> Event arch
   -- | A low-level trace event that contains a formula that should be displayed
   -- to the user in some structured way, when possible
   --

--- a/src/Pate/ExprMappable.hs
+++ b/src/Pate/ExprMappable.hs
@@ -17,6 +17,8 @@
 
 -- must come after TypeFamilies, see also https://gitlab.haskell.org/ghc/ghc/issues/18006
 {-# LANGUAGE NoMonoLocalBinds #-}
+{-# OPTIONS_GHC -fno-warn-simplifiable-class-constraints #-}
+
 module Pate.ExprMappable (
     ExprMappable(..)
   , ExprFoldable(..)

--- a/src/Pate/Hints/BSI.hs
+++ b/src/Pate/Hints/BSI.hs
@@ -5,21 +5,13 @@ module Pate.Hints.BSI (
   parseSymbolSpecHints
   ) where
 
-import           Control.Applicative ( (<|>) )
-import           Control.Monad ( guard )
 import qualified Data.Aeson as JSON
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Foldable as F
-import           Data.Function ( on )
 import qualified Data.HashMap.Strict as HMS
-import qualified Data.List as L
-import           Data.Maybe ( fromMaybe, mapMaybe )
+import           Data.Maybe ( fromMaybe )
 import qualified Data.Scientific as DS
 import qualified Data.Text as T
-import           Data.Word ( Word32, Word64 )
-import qualified Text.Megaparsec as MP
-import qualified Text.Megaparsec.Char as MPC
-import qualified Text.Megaparsec.Char.Lexer as MPCL
 
 import qualified Pate.Hints as PH
 

--- a/src/Pate/Interactive/Render/Proof.hs
+++ b/src/Pate/Interactive/Render/Proof.hs
@@ -3,8 +3,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-{-# OPTIONS_GHC -fno-warn-deprecations #-}
-
 module Pate.Interactive.Render.Proof (
     renderProof
   , renderProofApp

--- a/src/Pate/Location.hs
+++ b/src/Pate/Location.hs
@@ -43,6 +43,7 @@ import qualified What4.Interface as W4
 import qualified What4.PredMap as WPM
 
 import           Pate.TraceTree
+import qualified Data.Parameterized.TraversableF as TF
 
 -- | Generalized location-based traversals
 
@@ -164,4 +165,4 @@ instance (LocationTraversable sym arch a, LocationTraversable sym arch b) =>
 
 instance (forall bin. (LocationWitherable sym arch (f bin))) =>
   LocationWitherable sym arch (PPa.PatchPair f) where
-  witherLocation sym (PPa.PatchPair a b) f = PPa.PatchPair <$> witherLocation sym a f <*> witherLocation sym b f
+  witherLocation sym pp f = TF.traverseF (\x -> witherLocation sym x f) pp

--- a/src/Pate/Monad.hs
+++ b/src/Pate/Monad.hs
@@ -99,8 +99,7 @@ module Pate.Monad
   , subTrace
   , subTree
   , getWrappedSolver
-  , catchInIO
-  , andPatchPred)
+  , catchInIO, joinPatchPred)
   where
 
 import           GHC.Stack ( HasCallStack, callStack )
@@ -303,10 +302,10 @@ instance PPa.PatchPairM (EquivM_ sym arch) where
                                       Left (PEE.SomeInnerError PEE.InconsistentPatchPairAccess) -> b
                                       _ -> throwError e)
 
-andPatchPred ::
+joinPatchPred ::
   (forall bin. PBi.KnownBinary bin => PBi.WhichBinaryRepr bin -> EquivM_ sym arch (W4.Pred sym)) ->
   EquivM sym arch (W4.Pred sym)
-andPatchPred f = (PPa.forBinsC f) >>= \case
+joinPatchPred f = (PPa.forBinsC f) >>= \case
   PPa.PatchPairC a b -> withSym $ \sym -> liftIO $ W4.andPred sym a b
   PPa.PatchPairSingle _ (Const a) -> return a
 

--- a/src/Pate/Monad.hs
+++ b/src/Pate/Monad.hs
@@ -296,6 +296,12 @@ instance MonadTreeBuilder '(sym, arch) (EquivM_ sym arch) where
   getTreeBuilder = CMR.asks envTreeBuilder
   withTreeBuilder treeBuilder f = CMR.local (\env -> env { envTreeBuilder = treeBuilder }) f
 
+instance PPa.PatchPairError PEE.EquivalenceError where
+  patchPairErr = PEE.loaderError PEE.InconsistentPatchPairAccess
+
+instance PPa.PatchPairM PEE.EquivalenceError (EquivM_ sym arch) where
+  getPairRepr = CMR.asks envPatchPairRepr
+
 type ValidSymArch (sym :: Type) (arch :: Type) = (PSo.ValidSym sym, PA.ValidArch arch)
 type EquivM sym arch a = ValidSymArch sym arch => EquivM_ sym arch a
 
@@ -346,7 +352,7 @@ getBinCtx = getBinCtx' knownRepr
 getBinCtx' ::
   PBi.WhichBinaryRepr bin ->
   EquivM sym arch (PMC.BinaryContext arch bin)
-getBinCtx' repr = PPa.getPair' repr <$> CMR.asks (PMC.binCtxs . envCtx)
+getBinCtx' repr = PPa.get repr =<< (CMR.asks (PMC.binCtxs . envCtx))
 
 withValid :: forall a sym arch.
   (forall t st fs . (sym ~ WE.ExprBuilder t st fs, PA.ValidArch arch, PSo.ValidSym sym) => EquivM sym arch a) ->

--- a/src/Pate/Monad.hs
+++ b/src/Pate/Monad.hs
@@ -296,15 +296,14 @@ instance MonadTreeBuilder '(sym, arch) (EquivM_ sym arch) where
   getTreeBuilder = CMR.asks envTreeBuilder
   withTreeBuilder treeBuilder f = CMR.local (\env -> env { envTreeBuilder = treeBuilder }) f
 
-instance PPa.PatchPairError PEE.EquivalenceError where
-  patchPairErr = PEE.loaderError PEE.InconsistentPatchPairAccess
-
-instance PPa.PatchPairM PEE.EquivalenceError (EquivM_ sym arch) where
-  getPairRepr = CMR.asks envPatchPairRepr
+instance PPa.PatchPairM (EquivM_ sym arch) where
+  throwPairErr = throwHere $ PEE.InconsistentPatchPairAccess
+  catchPairErr a b = catchError a (\e -> case PEE.errEquivError e of
+                                      Left (PEE.SomeInnerError PEE.InconsistentPatchPairAccess) -> b
+                                      _ -> throwError e)
 
 type ValidSymArch (sym :: Type) (arch :: Type) = (PSo.ValidSym sym, PA.ValidArch arch)
 type EquivM sym arch a = ValidSymArch sym arch => EquivM_ sym arch a
-
 
 
 newtype ExprLabel = ExprLabel String

--- a/src/Pate/Monad/Environment.hs
+++ b/src/Pate/Monad/Environment.hs
@@ -108,7 +108,6 @@ data EquivEnv sym arch where
     , envSatCacheRef :: IO.IORef (SolverCache sym)
     , envTargetEquivRegs :: Set.Set (Some (MC.ArchReg arch))
     , envPtrAssertions :: MT.PtrAssertions sym
-    , envPatchPairRepr :: PPa.PatchPair PBi.WhichBinaryRepr
     } -> EquivEnv sym arch
 
 -- pushing assumption contexts should:

--- a/src/Pate/Monad/Environment.hs
+++ b/src/Pate/Monad/Environment.hs
@@ -108,6 +108,7 @@ data EquivEnv sym arch where
     , envSatCacheRef :: IO.IORef (SolverCache sym)
     , envTargetEquivRegs :: Set.Set (Some (MC.ArchReg arch))
     , envPtrAssertions :: MT.PtrAssertions sym
+    , envPatchPairRepr :: PPa.PatchPair PBi.WhichBinaryRepr
     } -> EquivEnv sym arch
 
 -- pushing assumption contexts should:

--- a/src/Pate/PatchPair.hs
+++ b/src/Pate/PatchPair.hs
@@ -10,30 +10,56 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Pate.PatchPair (
-    PatchPair(..)
+    PatchPair
+  , pattern PatchPair
+  , pattern PatchPairSingle
+  , PatchPairError(..)
+  , PatchPairM(..)
+  , PatchPairT
+  , PatchPairC
+  , pattern PatchPairC
+  , withPatchPairT
+  , pOriginal
+  , pPatched
+  , pcOriginal
+  , pcPatched
   , patchPairRepr
   , mkPair
-  , PatchPairC(..)
-  , toPatchPairC
-  , mergePatchPairCs
-  , zipMPatchPairC
+  , mkSingle
   , ppPatchPairCEq
   , ppPatchPairEq
   , ppPatchPairC
   , ppPatchPair
   , ppPatchPair'
-  , get
   , forBins
-  , forBins'
   , forBinsC
   , catBins
-  , getPair'
-  , setPair
+  , get
+  , set
   , ppEq
-  , forBinsL
+  , LiftF(..)
+  , PatchPairF
+  , pattern PatchPairF
+  , forBinsF
+  
   ) where
+
+import           Control.Monad.Trans.Maybe
+import           Control.Monad.Error
+import           Control.Monad.Catch
+import qualified Control.Monad.Reader as CMR
+import qualified Control.Monad.Trans as CMT
+import qualified Control.Monad.Trans.Except as CME
+import           Control.Exception
+import           Control.Monad.IO.Class
 
 import           Data.Functor.Const ( Const(..) )
 import qualified Data.Kind as DK
@@ -44,91 +70,206 @@ import qualified Prettyprinter as PP
 import qualified Pate.Binary as PB
 import qualified Pate.ExprMappable as PEM
 
-data PatchPair (tp :: PB.WhichBinary -> DK.Type) = PatchPair
+{-# DEPRECATED PatchPairCtor,pOriginal,pPatched,pcOriginal,pcPatched  "Use accessors" #-}
+-- | A pair of values indexed based on which binary they are associated with (either the
+--   original binary or the patched binary).
+--   A 'PatchPair' may also be a singleton (i.e. only containing a value for either the original
+--   or patched binary). During most of the verification process, all 'PatchPair' values are
+--   "full" (i.e. containing values for both binaries). Singleton 'PatchPair' values are used
+--   to handle cases where the control flow between the binaries has diverged and the verifier
+--   needs to handle each one independently.
+data PatchPair (tp :: PB.WhichBinary -> DK.Type) = PatchPairCtor
   { pOriginal :: tp PB.Original
   , pPatched :: tp PB.Patched
   }
+  | forall bin. PB.KnownBinary bin => PatchPairSingle (PB.WhichBinaryRepr bin) (tp bin)
 
-getPair' :: PB.WhichBinaryRepr bin -> PatchPair tp -> tp bin
-getPair' PB.OriginalRepr pPair = pOriginal pPair
-getPair' PB.PatchedRepr pPair = pPatched pPair
+pattern PatchPair :: (tp PB.Original) -> (tp PB.Patched) -> PatchPair tp
+pattern PatchPair a b = PatchPairCtor a b
+
+pattern PatchPairOriginal :: tp PB.Original -> PatchPair tp
+pattern PatchPairOriginal a = PatchPairSingle PB.OriginalRepr a
+
+pattern PatchPairPatched :: tp PB.Patched -> PatchPair tp
+pattern PatchPairPatched a = PatchPairSingle PB.PatchedRepr a
+
+{-# COMPLETE PatchPair, PatchPairSingle #-}
+{-# COMPLETE PatchPair, PatchPairOriginal, PatchPairPatched #-}
+
+-- | Select the value from the 'PatchPair' according to the given 'PB.WhichBinaryRepr'
+--   Returns 'Nothing' if the given 'PatchPair' does not contain a value for the given binary
+--   (i.e. it is a singleton 'PatchPair' and the opposite binary repr is given)
+getPair :: PB.WhichBinaryRepr bin -> (forall tp. PatchPair tp -> Maybe (tp bin))
+getPair repr pPair = case pPair of
+  PatchPair orig patched -> case repr of
+    PB.OriginalRepr -> Just orig
+    PB.PatchedRepr -> Just patched
+  PatchPairSingle repr' a | Just Refl <- testEquality repr repr' -> Just a
+  _ -> Nothing
+
+-- | Set the value in the given 'PatchPair' according to the given 'PB.WhichBinaryRepr'
+--   Returns 'Nothing' if the given 'PatchPair' does not contain a value for the given binary.
+--   (n.b. this will not convert a singleton 'PatchPair' into a full 'PatchPair')
+setPair :: PB.WhichBinaryRepr bin -> (forall tp. PatchPair tp -> tp bin -> Maybe (PatchPair tp))
+setPair PB.OriginalRepr pPair a = case pPair of
+  PatchPair _ patched -> Just $ PatchPair a patched
+  PatchPairOriginal _ -> Just $ PatchPairOriginal a
+  PatchPairPatched _ -> Nothing
+setPair PB.PatchedRepr pPair a = case pPair of
+  PatchPair orig _ -> Just $ PatchPair orig a
+  PatchPairPatched _ -> Just $ PatchPairPatched a
+  PatchPairOriginal _ -> Nothing
 
 
-setPair :: PB.WhichBinaryRepr bin -> tp bin -> PatchPair tp -> PatchPair tp
-setPair PB.OriginalRepr a pPair = pPair { pOriginal = a }
-setPair PB.PatchedRepr a pPair = pPair { pPatched = a }
+class PatchPairError e where
+  patchPairErr :: e
 
-get :: forall bin tp. PB.KnownBinary bin => PatchPair tp -> tp bin
-get = getPair' knownRepr
+-- | The 'PatchPairM' class defines how a monad should handle mismatched 'PatchPair' values.
+--   Specifically there is always a background 'PatchPair PB.WhichBinaryRepr' that controls
+--   the shape of all new 'PatchPair' values.
+class (PatchPairError e, MonadError e m) => PatchPairM e m | m -> e where
+  getPairRepr :: m (PatchPair PB.WhichBinaryRepr)
+  -- ^ controls how all 'PatchPair' values are traversed and the shape of all new 'PatchPair'
+  --   values (i.e. if this is a singleton "original" 'PatchPair' then all traversals will be
+  --   limited to "original" values and all new 'PatchPair' values will be "original" singletons)
+
+instance PatchPairError () where
+  patchPairErr = ()
+
+instance PatchPairM () Maybe where
+  getPairRepr = return patchPairRepr
+
+instance PatchPairM e m => PatchPairM e (MaybeT m) where
+  getPairRepr = CMT.lift getPairRepr
+
+liftPairErr :: PatchPairM e m => Maybe a -> m a
+liftPairErr (Just a) = return a
+liftPairErr Nothing = throwError patchPairErr
+
+-- | Select the value from the 'PatchPair' according to the given 'PB.WhichBinaryRepr'
+--   Raises 'pairErr' if the given 'PatchPair' does not contain a value for the given binary.
+get :: PatchPairM e m => PB.WhichBinaryRepr bin -> (forall tp. PatchPair tp -> m (tp bin))
+get repr pPair = liftPairErr (getPair repr pPair)
+
+-- | Set the value in the given 'PatchPair' according to the given 'PB.WhichBinaryRepr'
+--   Raises 'pairErr' if the given 'PatchPair' does not contain a value for the given binary.
+set :: PatchPairM e m => PB.WhichBinaryRepr bin -> (forall tp. PatchPair tp -> tp bin -> m (PatchPair tp))
+set repr pPair a = liftPairErr (setPair repr pPair a)
+
+-- | Simple monadic transformer for giving a default 'PatchPairM' implementation
+--   to any monad.
+newtype PatchPairT m a = PatchPairT (CMR.ReaderT (PatchPair PB.WhichBinaryRepr) m a)
+  deriving (Functor, Applicative, Monad, CMR.MonadReader (PatchPair PB.WhichBinaryRepr), CMR.MonadTrans)
+
+deriving instance MonadError e m => MonadError e (PatchPairT m)
+deriving instance MonadThrow m => MonadThrow (PatchPairT m)
+deriving instance MonadIO m => MonadIO (PatchPairT m)
+deriving instance MonadFail m => MonadFail (PatchPairT m)
+
+instance PatchPairError IOException where
+  patchPairErr = userError "PatchPair: unexpected incompatible binaries in PatchPair combination"
+
+instance (PatchPairError e, MonadError e m) => PatchPairM e (PatchPairT m) where
+  getPairRepr = CMR.ask
+
+-- | Run a 'PatchPairT' computation, using the given 'PatchPair' as the basis
+--  for the underlying 'getPairRepr'.
+--  NOTE: 'PatchPairT' only satisfies 'PatchPairM' if the monad 'm' is a
+--  'MonadError' with an error that has a 'PatchPairError' instance
+withPatchPairT :: PatchPair x -> PatchPairT m a -> m a
+withPatchPairT pPair (PatchPairT m) = CMR.runReaderT m (toPatchPairRepr pPair)
 
 patchPairRepr :: PatchPair PB.WhichBinaryRepr
 patchPairRepr = PatchPair PB.OriginalRepr PB.PatchedRepr
+
+toPatchPairRepr :: PatchPair x -> PatchPair PB.WhichBinaryRepr
+toPatchPairRepr = \case
+  PatchPair{} -> patchPairRepr
+  PatchPairSingle bin _ -> PatchPairSingle bin bin
 
 mkPair :: PB.WhichBinaryRepr bin -> tp bin -> tp (PB.OtherBinary bin) -> PatchPair tp
 mkPair bin b1 b2 = case bin of
   PB.OriginalRepr -> PatchPair b1 b2
   PB.PatchedRepr -> PatchPair b2 b1
 
-forBins :: Applicative m => (forall bin. PB.KnownBinary bin => (forall tp. PatchPair tp -> tp bin) -> m (f bin)) -> m (PatchPair f)
-forBins f = PatchPair <$> f (get @PB.Original) <*> f (get @PB.Patched)
+mkSingle :: PB.KnownBinary bin => tp bin -> PatchPair tp
+mkSingle a = PatchPairSingle knownRepr a
 
-forBins' :: Applicative m => (forall bin. PB.KnownBinary bin => PB.WhichBinaryRepr bin -> m (f bin)) -> m (PatchPair f)
-forBins' f = PatchPair <$> f PB.OriginalRepr <*> f PB.PatchedRepr
+-- | Create a 'PatchPair' with a shape according to 'getPairRepr'.
+--   The provided function is run once for each value in the 'PatchPair' (i.e. twice for a full
+--   'PatchPair' or once for a singleton).
+--    Note: in the case where 'getPairRepr' is a singleton, the default error for 'PatchPairM' will
+--    be raised if the getter or setter is applied to a singleton 'PatchPair' for the opposite binary.
+forBins :: PatchPairM e m => (forall bin. PB.KnownBinary bin => PB.WhichBinaryRepr bin -> m (f bin)) -> m (PatchPair f)
+forBins f = getPairRepr >>= \case
+  PatchPair{} -> PatchPair
+    <$> (f PB.OriginalRepr)
+    <*> (f PB.PatchedRepr)
+  PatchPairOriginal{} -> PatchPairOriginal <$> (f PB.OriginalRepr)
+  PatchPairPatched{} -> PatchPairPatched <$> (f PB.PatchedRepr)
 
-forBinsC :: Applicative m => (forall bin. PB.KnownBinary bin => (forall tp. PatchPair tp -> tp bin) -> m f) -> m (f, f)
-forBinsC f = (,) <$> f (get @PB.Original) <*> f (get @PB.Patched)
+{-
+forBins :: PatchPairM m => (forall bin. PB.KnownBinary bin => PairGetter bin m -> PairSetter bin m -> m (f bin)) -> m (PatchPair f)
+forBins f = forBins_ $ \bin -> f (getPair bin) (setPair bin)
+-}
 
-forBinsL :: Applicative m => (forall bin. PB.KnownBinary bin => (forall tp. PatchPair tp -> tp bin) -> m [f bin]) -> m ([f PB.Original], [f PB.Patched])
-forBinsL f = (,) <$> f (get @PB.Original)  <*> f (get @PB.Patched)
+-- | Specialization of 'PatchPair' to types which are not indexed on 'PB.WhichBinary'
+type PatchPairC tp = PatchPair (Const tp)
 
-catBins :: Applicative m => Semigroup w => (forall bin. PB.KnownBinary bin => (forall tp. PatchPair tp -> tp bin) -> m w) -> m w
-catBins f = (<>) <$> f (get @PB.Original) <*> f (get @PB.Patched)
+pattern PatchPairC :: tp -> tp -> PatchPair (Const tp)
+pattern PatchPairC a b = PatchPairCtor (Const a) (Const b)
+
+{-# COMPLETE PatchPairC, PatchPairSingle #-}
+
+pcOriginal :: PatchPairC tp -> tp
+pcOriginal = getConst . pOriginal
+
+pcPatched :: PatchPairC tp -> tp
+pcPatched = getConst . pPatched
+
+-- | The same as 'forBins' but specialized to 'PatchPairC' (i.e. when type in the 'PatchPair' is not
+--   indexed by 'PB.WhichBinary')
+forBinsC :: PatchPairM e m => (forall bin. PB.KnownBinary bin => PB.WhichBinaryRepr bin -> m f) -> m (PatchPairC f)
+forBinsC f = forBins $ \bin -> Const <$> f bin
+
+newtype LiftF (t :: l -> DK.Type) (f :: k -> l) (tp :: k) = LiftF { unLiftF :: (t (f tp)) }
+
+-- | Specialization of 'PatchPair' to lift inner types over the 'bin' parameter.
+type PatchPairF t tp = PatchPair (LiftF t tp)
+
+pattern PatchPairF :: t (tp PB.Original) -> t (tp PB.Patched) -> PatchPair (LiftF t tp)
+pattern PatchPairF a b = PatchPairCtor (LiftF a) (LiftF b)
+
+{-# COMPLETE PatchPairF, PatchPairSingle #-}
+
+forBinsF :: PatchPairM e m => (forall bin. PB.KnownBinary bin => PB.WhichBinaryRepr bin -> m (t (f bin))) -> m (PatchPairF t f)
+forBinsF f = forBins $ \bin -> LiftF <$> f bin
+
+-- | Run the given function once for each value in the current 'getPairRepr', and then concatenate the result.
+--   For singleton 'PatchPair' values this is just the result of running the function once.
+catBins :: PatchPairM e m => Semigroup w => (forall bin. PB.KnownBinary bin => PB.WhichBinaryRepr bin -> m w) -> m w
+catBins f = forBinsC f >>= \case
+  PatchPair (Const a) (Const b) -> pure (a <> b)
+  PatchPairSingle _ (Const a) -> pure a
 
 -- | True if the two given values would be printed identically
 ppEq :: PP.Pretty x => PP.Pretty y => x -> y -> Bool
 ppEq x y = show (PP.pretty x) == show (PP.pretty y)
-
-data PatchPairC tp = PatchPairC
-  { pcOriginal :: tp
-  , pcPatched :: tp
-  }
-  deriving (Eq, Ord, Functor, Foldable, Traversable)
-
-instance (PEM.ExprMappable sym tp) => PEM.ExprMappable sym (PatchPairC tp) where
-  mapExpr sym f (PatchPairC a1 a2) = PatchPairC
-    <$> PEM.mapExpr sym f a1
-    <*> PEM.mapExpr sym f a2
-
-toPatchPairC ::
-  PatchPair (Const f) ->
-  PatchPairC f
-toPatchPairC (PatchPair (Const v1) (Const v2)) = PatchPairC v1 v2
-
-mergePatchPairCs ::
-  PatchPairC a ->
-  PatchPairC b ->
-  PatchPairC (a, b)
-mergePatchPairCs (PatchPairC o1 p1) (PatchPairC o2 p2) = PatchPairC (o1, o2) (p1, p2)
-
-zipMPatchPairC ::
-  Applicative m =>
-  PatchPairC a ->
-  PatchPairC b ->
-  (a -> b -> m c) ->
-  m (PatchPairC c)
-zipMPatchPairC (PatchPairC a1 a2) (PatchPairC b1 b2) f = PatchPairC
-  <$> f a1 b1
-  <*> f a2 b2
 
 instance TestEquality tp => Eq (PatchPair tp) where
   PatchPair o1 p1 == PatchPair o2 p2
     | Just Refl <- testEquality o1 o2
     , Just Refl <- testEquality p1 p2
     = True
+  PatchPairSingle _ a1 == PatchPairSingle _ a2 | Just Refl <- testEquality a1 a2 = True
   _ == _ = False
 
-instance (TestEquality tp, OrdF tp) => Ord (PatchPair tp) where
-  compare (PatchPair o1 p1) (PatchPair o2 p2) = toOrdering $ (lexCompareF o1 o2 (compareF p1 p2))
+instance forall tp. (TestEquality tp, OrdF tp) => Ord (PatchPair tp) where
+  compare pp1 pp2 = case (pp1,pp2) of
+    (PatchPair o1 p1, PatchPair o2 p2) -> toOrdering $ (lexCompareF o1 o2 (compareF p1 p2))
+    (PatchPairSingle _ s1, PatchPairSingle _ s2) -> toOrdering $ compareF s1 s2
+    (PatchPairSingle{},PatchPair{}) -> LT
+    (PatchPair{},PatchPairSingle{}) -> GT
 
 instance TF.FunctorF PatchPair where
   fmapF = TF.fmapFDefault
@@ -137,15 +278,18 @@ instance TF.FoldableF PatchPair where
   foldMapF = TF.foldMapFDefault
 
 instance (forall bin. PEM.ExprMappable sym (f bin)) => PEM.ExprMappable sym (PatchPair f) where
-  mapExpr sym f (PatchPair o p) = PatchPair <$> PEM.mapExpr sym f o <*> PEM.mapExpr sym f p
+  mapExpr sym f pp = TF.traverseF (PEM.mapExpr sym f) pp
 
 instance TF.TraversableF PatchPair where
-  traverseF f (PatchPair o p) = PatchPair <$> f o <*> f p
-
+  traverseF f pp = case pp of
+    (PatchPair o p) -> PatchPair <$> f o <*> f p
+    (PatchPairSingle bin s) -> PatchPairSingle bin <$> f s
 
 
 instance ShowF tp => Show (PatchPair tp) where
   show (PatchPair a1 a2) = showF a1 ++ " vs. " ++ showF a2
+  show (PatchPairOriginal a1) = showF a1 ++ " (original)"
+  show (PatchPairPatched a1) = showF a1 ++ " (patched)"
 
 instance (forall bin. PP.Pretty (f bin)) => PP.Pretty (PatchPair f) where
   pretty = ppPatchPairEq ppEq PP.pretty
@@ -156,7 +300,8 @@ ppPatchPair' f pPair = ppPatchPairEq (\x y -> show (f x) == show (f y)) f pPair
 
 ppPatchPair :: (forall bin. tp bin -> PP.Doc a) -> PatchPair tp -> PP.Doc a
 ppPatchPair f (PatchPair a1 a2) = f a1 PP.<+> PP.pretty "(original) vs." PP.<+> f a2 PP.<+> PP.pretty "(patched)"
-
+ppPatchPair f (PatchPairOriginal a1) = f a1 PP.<+> PP.pretty "(original)"
+ppPatchPair f (PatchPairPatched a1) = f a1 PP.<+> PP.pretty "(patched)"
 
 ppPatchPairEq ::
   (tp PB.Original -> tp PB.Patched -> Bool) ->
@@ -166,21 +311,26 @@ ppPatchPairEq ::
 ppPatchPairEq test f (PatchPair a1 a2) = case test a1 a2 of
   True -> f a1
   False -> f a1 PP.<+> PP.pretty "(original) vs." PP.<+> f a2 PP.<+> PP.pretty "(patched)"
+ppPatchPairEq _ f pPair = ppPatchPair f pPair
+
+
 
 ppPatchPairC ::
   (tp -> PP.Doc a) ->
   PatchPairC tp ->
   PP.Doc a
-ppPatchPairC f (PatchPairC o p) = ppPatchPair (\(Const v) -> f v) (PatchPair (Const o) (Const p))
+ppPatchPairC f ppair = ppPatchPair (\(Const v) -> f v) ppair
 
 ppPatchPairCEq ::
   Eq tp =>
   (tp -> PP.Doc a) ->
   PatchPairC tp ->
   PP.Doc a
-ppPatchPairCEq f ppair@(PatchPairC o p) = case o == p of
+ppPatchPairCEq f ppair@(PatchPair (Const o) (Const p)) = case o == p of
   True -> f o
   False -> ppPatchPairC f ppair
+ppPatchPairCEq f (PatchPairOriginal (Const a)) = f a PP.<+> PP.pretty "(original)"
+ppPatchPairCEq f (PatchPairPatched (Const a)) = f a PP.<+> PP.pretty "(patched)"
 
 
 

--- a/src/Pate/Proof.hs
+++ b/src/Pate/Proof.hs
@@ -64,6 +64,7 @@ module Pate.Proof
   , emptyCondEqResult
   ) where
 
+import           Data.Functor.Const
 import           Control.Monad.Identity
 import           Control.Monad.Writer.Strict as CMW
 import qualified Data.Kind as DK
@@ -73,6 +74,7 @@ import           Data.Parameterized.Some
 import           Data.Parameterized.Classes
 import qualified Data.Parameterized.Nonce as N
 import qualified Data.Parameterized.Map as MapF
+import qualified Data.Parameterized.TraversableF as TF
 
 import qualified Data.Macaw.CFG as MM
 import qualified Data.Macaw.CFGSlice as MCS
@@ -425,7 +427,7 @@ data BlockSliceRegOp sym tp where
 
 instance PEM.ExprMappable sym (BlockSliceRegOp sym tp) where
   mapExpr sym f regOp = BlockSliceRegOp
-    <$> traverse (PEM.mapExpr sym f) (slRegOpValues regOp)
+    <$> TF.traverseF (PEM.mapExpr sym f) (slRegOpValues regOp)
     <*> pure (slRegOpRepr regOp)
     <*> f (slRegOpEquiv regOp)
 
@@ -444,7 +446,7 @@ data BlockSliceMemOp sym w where
 
 instance PEM.ExprMappable sym (BlockSliceMemOp sym w) where
   mapExpr sym f memOp = BlockSliceMemOp
-    <$> traverse (W4H.mapExprPtr sym f) (slMemOpValues memOp)
+    <$> TF.traverseF (\(Const x) -> Const <$> W4H.mapExprPtr sym f x) (slMemOpValues memOp)
     <*> f (slMemOpEquiv memOp)
     <*> f (slMemOpCond memOp)
 

--- a/src/Pate/Proof/Instances.hs
+++ b/src/Pate/Proof/Instances.hs
@@ -26,6 +26,7 @@ Instantiations for the leaves of the proof types
 {-# LANGUAGE ConstraintKinds #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
 
 module Pate.Proof.Instances
   ( SomeProofNonceExpr(..)
@@ -174,6 +175,7 @@ instance forall sym arch tp. (PA.ValidArch arch, PSo.ValidSym sym) => PP.Pretty 
        where
          go :: (PB.ConcreteBlock arch bin, PB.ConcreteBlock arch bin) -> PP.Doc a
          go (src, tgt) = PP.parens (PP.pretty (PB.ppBlock src)) <+> "->" <+> (PP.pretty (PB.ppBlock tgt))
+     ppBlockPairTarget _ _ = PPa.handleSingletonStub
  pretty (PF.ProofExpr prf@PF.ProofBlockSlice{}) =
     PP.vsep
       [ PP.pretty (PF.prfBlockSliceTriple prf)
@@ -435,7 +437,7 @@ ppIPs st  =
     pcRegs = (PF.slRegState st) ^. MM.curIP
     vals = TF.fmapF (\(Const x) -> Const $ groundMacawValue x) (PF.slRegOpValues pcRegs)
   in case PG.groundValue $ PF.slRegOpEquiv pcRegs of
-    True -> PP.pretty $ PPa.pcOriginal vals
+    True -> PP.pretty $ PPa.someC vals
     False -> PPa.ppPatchPairC PP.pretty vals
 
 ppMemCellMap ::
@@ -555,7 +557,7 @@ ppRegVal dom reg regOp = case PF.slRegOpRepr regOp of
       False -> "| Excluded"
     
     ppVals = case PG.groundValue $ PF.slRegOpEquiv regOp of
-      True -> PP.pretty $ PPa.pcOriginal vals
+      True -> PP.pretty $ PPa.someC vals
       False -> PPa.ppPatchPairC PP.pretty vals
 
 regInGroundDomain ::
@@ -588,7 +590,7 @@ ppCellVal dom cell memOp = case PG.groundValue $ PF.slMemOpCond memOp of
       False -> "| Excluded"
  
     ppVals = case PG.groundValue $ PF.slMemOpEquiv memOp of
-      True -> PP.pretty $ show (PPa.pcOriginal vals)
+      True -> PP.pretty $ show (PPa.someC vals)
       False -> PPa.ppPatchPairC (PP.pretty . show) vals
 
 ppGroundCell ::

--- a/src/Pate/Proof/Instances.hs
+++ b/src/Pate/Proof/Instances.hs
@@ -26,7 +26,6 @@ Instantiations for the leaves of the proof types
 {-# LANGUAGE ConstraintKinds #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# OPTIONS_GHC -fno-warn-deprecations #-}
 
 module Pate.Proof.Instances
   ( SomeProofNonceExpr(..)

--- a/src/Pate/Proof/Operations.hs
+++ b/src/Pate/Proof/Operations.hs
@@ -16,8 +16,6 @@ Functions for creating and operating with equivalence proofs
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE LambdaCase #-}
 
-{-# OPTIONS_GHC -fno-warn-deprecations #-}
-
 module Pate.Proof.Operations
   ( simBundleToSlice
   , noTransition
@@ -77,7 +75,7 @@ import qualified Pate.SimulatorRegisters as PSR
 import qualified Pate.Binary as PBi
 
 
--- FIXME: These were originally define in SimState.hs but were moved here
+-- FIXME: These were originally defined in SimState.hs but were moved here
 -- since this code is largely deprecated
 simInO :: SimBundle sym arch v -> PS.SimInput sym arch v PBi.Original
 simInO bundle = case simIn bundle of

--- a/src/Pate/Proof/Operations.hs
+++ b/src/Pate/Proof/Operations.hs
@@ -16,6 +16,8 @@ Functions for creating and operating with equivalence proofs
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE LambdaCase #-}
 
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+
 module Pate.Proof.Operations
   ( simBundleToSlice
   , noTransition
@@ -72,6 +74,34 @@ import qualified Pate.Proof.Instances as PFI
 import qualified Pate.Register.Traversal as PRt
 import qualified Pate.SimState as PS
 import qualified Pate.SimulatorRegisters as PSR
+import qualified Pate.Binary as PBi
+
+
+-- FIXME: These were originally define in SimState.hs but were moved here
+-- since this code is largely deprecated
+simInO :: SimBundle sym arch v -> PS.SimInput sym arch v PBi.Original
+simInO bundle = case simIn bundle of
+  PPa.PatchPair o _ -> o
+  PPa.PatchPairOriginal o -> o
+  _ -> PPa.handleSingletonStub
+
+simInP :: SimBundle sym arch v -> PS.SimInput sym arch v PBi.Patched
+simInP bundle = case simIn bundle of
+  PPa.PatchPair _ p -> p
+  PPa.PatchPairPatched p -> p
+  _ -> PPa.handleSingletonStub
+
+simOutO :: SimBundle sym arch v -> PS.SimOutput sym arch v PBi.Original
+simOutO bundle = case simOut bundle of
+  PPa.PatchPair o _ -> o
+  PPa.PatchPairOriginal o -> o
+  _ -> PPa.handleSingletonStub
+
+simOutP :: SimBundle sym arch v -> PS.SimOutput sym arch v PBi.Patched
+simOutP bundle = case simOut bundle of
+  PPa.PatchPair _ p -> p
+  PPa.PatchPairPatched p -> p
+  _ -> PPa.handleSingletonStub
 
 -- | Convert the result of symbolic execution into a structured slice
 -- representation
@@ -80,8 +110,8 @@ simBundleToSlice ::
   EquivM sym arch (PF.BlockSliceTransition sym arch)
 simBundleToSlice bundle = withSym $ \sym -> do
   let
-    ecaseO = PS.simOutBlockEnd $ PS.simOutO $ bundle
-    ecaseP = PS.simOutBlockEnd $ PS.simOutP $ bundle
+    ecaseO = PS.simOutBlockEnd $ simOutO $ bundle
+    ecaseP = PS.simOutBlockEnd $ simOutP $ bundle
   footprints <- getFootprints bundle
   memReads <- PEM.toList <$> (liftIO $ PEM.fromFootPrints sym (S.filter (MT.isDir MT.Read) footprints))
   memWrites <- PEM.toList <$> (liftIO $ PEM.fromFootPrints sym (S.filter (MT.isDir MT.Write) footprints))
@@ -89,8 +119,8 @@ simBundleToSlice bundle = withSym $ \sym -> do
   preMem <- MapF.fromList <$> mapM (\x -> memCellToOp initState x) memReads
   postMem <- MapF.fromList <$> mapM (\x -> memCellToOp finState x) memWrites
 
-  preRegs <- PRt.zipWithRegStatesM (PS.simInRegs $ PS.simInO bundle) (PS.simInRegs $ PS.simInP bundle) (\r vo vp -> getReg r vo vp)
-  postRegs <- PRt.zipWithRegStatesM (PS.simOutRegs $ PS.simOutO bundle) (PS.simOutRegs $ PS.simOutP bundle) (\r vo vp -> getReg r vo vp)
+  preRegs <- PRt.zipWithRegStatesM (PS.simInRegs $ simInO bundle) (PS.simInRegs $ simInP bundle) (\r vo vp -> getReg r vo vp)
+  postRegs <- PRt.zipWithRegStatesM (PS.simOutRegs $ simOutO bundle) (PS.simOutRegs $ simOutP bundle) (\r vo vp -> getReg r vo vp)
   
   let
     preState = PF.BlockSliceState preMem preRegs
@@ -117,6 +147,7 @@ simBundleToSlice bundle = withSym $ \sym -> do
       PPa.PatchPair (PS.SimState sym arch v) ->
       (Some (PMC.MemCell sym arch), W4.Pred sym) ->
       EquivM sym arch (MapF.Pair (PMC.MemCell sym arch) (PF.BlockSliceMemOp sym))
+    memCellToOp (PPa.PatchPairSingle{}) _ = PPa.handleSingletonStub
     memCellToOp (PPa.PatchPair stO stP) (Some cell, cond) = withSym $ \sym -> do
       valO <- liftIO $ PMC.readMemCell sym (PS.simMem stO) cell
       valP <- liftIO $ PMC.readMemCell sym (PS.simMem stP) cell

--- a/src/Pate/SimState.hs
+++ b/src/Pate/SimState.hs
@@ -67,10 +67,6 @@ module Pate.SimState
   , simOutMem
   , simOutRegs
   , simPair
-  , simInO
-  , simInP
-  , simOutO
-  , simOutP
   , simSP
   -- variable binding
   , SimVars(..)
@@ -321,19 +317,6 @@ bundleOutVars bundle = TF.fmapF (SimVars . simOutState) (simOut bundle)
 
 bundleInVars :: SimBundle sym arch v -> PPa.PatchPair (SimVars sym arch v)
 bundleInVars bundle = TF.fmapF (SimVars . simInState) (simIn bundle)
-
-simInO :: SimBundle sym arch v -> SimInput sym arch v PBi.Original
-simInO = PPa.pOriginal . simIn
-
-simInP :: SimBundle sym arch v -> SimInput sym arch v PBi.Patched
-simInP = PPa.pPatched . simIn
-
-simOutO :: SimBundle sym arch v -> SimOutput sym arch v PBi.Original
-simOutO = PPa.pOriginal . simOut
-
-simOutP :: SimBundle sym arch v -> SimOutput sym arch v PBi.Patched
-simOutP = PPa.pPatched . simOut
-
 
 simPair :: SimBundle sym arch v -> PB.BlockPair arch
 simPair bundle = TF.fmapF simInBlock (simIn bundle)

--- a/src/Pate/SimState.hs
+++ b/src/Pate/SimState.hs
@@ -238,8 +238,8 @@ scopeVars scope = TF.fmapF boundVarsAsFree (scopeBoundVars scope)
 
 -- | Create a 'SimSpec' with "fresh" bound variables
 freshSimSpec ::
-  forall sym arch f e m.
-  PPa.PatchPairM e m =>
+  forall sym arch f m.
+  PPa.PatchPairM m =>
   MM.RegisterInfo (MM.ArchReg arch) =>
   -- | These must all be fresh variables
   (forall bin tp. PBi.WhichBinaryRepr bin -> MM.ArchReg arch tp -> m (PSR.MacawRegVar sym tp)) ->
@@ -571,7 +571,7 @@ getScopeCoercion ::
   IO (ScopeCoercion sym v1 v2)
 getScopeCoercion sym scope vals = do
   let vars = scopeBoundVars scope
-  binds <- PPa.withPatchPairT vars $ PPa.catBins $ \bin -> do
+  binds <- PPa.runPatchPairT $ PPa.catBins $ \bin -> do
     st <- simVarState <$> PPa.get bin vals
     vars' <- PPa.get bin vars
     lift $ mkVarBinds sym vars' (MT.memState $ simMem st) (simRegs st) (simStackBase st) (simMaxRegion st)

--- a/src/Pate/TraceTree.hs
+++ b/src/Pate/TraceTree.hs
@@ -84,6 +84,8 @@ module Pate.TraceTree (
   , withTracingLabel
   , withNoTracing
   , mkTags
+  , runNodeBuilderT
+  , getNodeBuilder
   ) where
 
 import           GHC.TypeLits ( Symbol, KnownSymbol )
@@ -208,7 +210,7 @@ addTreeDependency treeBuilder nodeBuilder =
         False -> updateNodeStatus nodeBuilder st
   in nodeBuilder { updateNodeStatus = finish }
 
-startTree :: forall k nm. IO (TraceTree k, TreeBuilder k)
+startTree :: forall k. IO (TraceTree k, TreeBuilder k)
 startTree  = do
   l <- emptyIOList
   let builder = TreeBuilder (\st -> propagateIOListStatus st l) (startNode' @k) (\node -> addIOList (Some node) l) 

--- a/src/Pate/Verification.hs
+++ b/src/Pate/Verification.hs
@@ -239,7 +239,7 @@ doVerifyPairs validArch logAction elf elf' vcfg pd gen sym = do
   let defaultInit = PA.validArchInitAbs archData
 
   -- inject an override for the initial abstract state
-  contexts1 <- PPa.withPatchPairT contexts $ PPa.forBins $ \bin -> do  
+  contexts1 <- PPa.runPatchPairT $ PPa.forBins $ \bin -> do  
     context' <- PPa.get bin contexts
     blk <- PPa.get bin entryPoint
     let

--- a/src/Pate/Verification/AbstractDomain.hs
+++ b/src/Pate/Verification/AbstractDomain.hs
@@ -656,7 +656,7 @@ absDomainToPrecond ::
 absDomainToPrecond sym eqCtx bundle d = PE.eqCtxConstraints eqCtx $ do
   eqInputs <- PE.getPredomain sym bundle eqCtx (absDomEq d)
   eqInputsPred <- PE.preCondAssumption sym (PS.simInO bundle) (PS.simInP bundle) eqCtx eqInputs
-  valsPred <- PPa.withPatchPairT (PS.simIn bundle) $ PPa.catBins $ \bin -> do
+  valsPred <- PPa.runPatchPairT $ PPa.catBins $ \bin -> do
     input <- PPa.get bin (PS.simIn bundle)
     let absBlockState = PS.simInAbsState input
     absDomVals' <- PPa.get bin (absDomVals d)

--- a/src/Pate/Verification/AbstractDomain.hs
+++ b/src/Pate/Verification/AbstractDomain.hs
@@ -467,7 +467,7 @@ widenAbsDomainVals sym prev f bundle = do
     (absVals', locs) <- widenAbsDomainVals' sym absVals f out
     return $ (absVals', Const locs)
 
-  locs' <- PPa.catBins $ \bin -> getConst <$> PPa.get bin locs
+  locs' <- PPa.catBins $ \bin -> PPa.getC bin locs
   return $ (prev {absDomVals = absVals'}, Just locs')
 
 applyAbsRange ::

--- a/src/Pate/Verification/InlineCallee.hs
+++ b/src/Pate/Verification/InlineCallee.hs
@@ -490,14 +490,15 @@ inlineCallee
   => PEE.EquivalenceDomain sym arch
   -> PB.BlockPair arch
   -> EquivM sym arch (PEE.EquivalenceDomain sym arch, PFO.LazyProof sym arch PF.ProofBlockSliceType)
-inlineCallee contPre pPair = withValid $ withSym $ \sym -> do
+inlineCallee _ (PPa.PatchPairSingle{}) = PPa.handleSingletonStub
+inlineCallee contPre pPair@(PPa.PatchPair blkO blkP) = withValid $ withSym $ \sym -> do
   -- Normally we would like to treat errors leniently and continue on in a degraded state
   --
   -- However, if the user has specifically asked for two functions to be equated
   -- and we can't find them, we will just call that a fail-stop error (i.e.,
   -- 'functionFor' can throw an exception).
-  Some oDFI <- functionFor @PBi.Original (PPa.pOriginal pPair)
-  Some pDFI <- functionFor @PBi.Patched (PPa.pPatched pPair)
+  Some oDFI <- functionFor @PBi.Original blkO
+  Some pDFI <- functionFor @PBi.Patched blkP
 
   origBinary <- PMC.binary <$> getBinCtx' PBi.OriginalRepr
   patchedBinary <- PMC.binary <$> getBinCtx' PBi.PatchedRepr

--- a/src/Pate/Verification/PairGraph.hs
+++ b/src/Pate/Verification/PairGraph.hs
@@ -9,7 +9,8 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE PatternSynonyms #-}
+
 
 module Pate.Verification.PairGraph
   ( Gas(..)
@@ -77,7 +78,7 @@ import qualified Pate.Equivalence.Error as PEE
 import qualified Pate.Verification.Domain as PVD
 import qualified Pate.SimState as PS
 
-import           Pate.Verification.PairGraph.Node ( GraphNode(..), NodeEntry, NodeReturn, graphNodeCases, rootEntry, nodeBlocks, rootReturn )
+import           Pate.Verification.PairGraph.Node ( GraphNode(..), NodeEntry, NodeReturn, pattern GraphNodeEntry, pattern GraphNodeReturn, rootEntry, nodeBlocks, rootReturn )
 import           Pate.Verification.StrongestPosts.CounterExample ( TotalityCounterexample(..), ObservableCounterexample(..) )
 
 import qualified Pate.Verification.AbstractDomain as PAD
@@ -407,11 +408,11 @@ initialDomainSpec ::
   forall sym arch.
   GraphNode arch ->
   EquivM sym arch (PAD.AbstractDomainSpec sym arch)
-initialDomainSpec (graphNodeCases -> Left blocks) =
+initialDomainSpec (GraphNodeEntry blocks) =
   withFreshVars blocks $ \_vars -> do
     dom <- initialDomain
     return (mempty, dom)
-initialDomainSpec (graphNodeCases -> Right fPair) = do
+initialDomainSpec (GraphNodeReturn fPair) = do
   let blocks = TF.fmapF PB.functionEntryToConcreteBlock fPair
   withFreshVars blocks $ \_vars -> do
     dom <- initialDomain

--- a/src/Pate/Verification/PairGraph.hs
+++ b/src/Pate/Verification/PairGraph.hs
@@ -440,8 +440,8 @@ initializePairGraph pPairs = foldM (\x y -> initPair x y) emptyPairGraph pPairs
            -- point is some intermediate program point), then this value domain will simply
            -- be overridden as a result of widening
            rootDom <- PS.forSpec idom $ \_ idom' -> do
-             vals' <- PPa.forBins $ \get -> do
-               let vals = get (PAD.absDomVals idom')
+             vals' <- PPa.forBins $ \bin -> do
+               vals <- PPa.get bin (PAD.absDomVals idom')
                -- FIXME: compute this from the global and stack regions
                return $ vals { PAD.absMaxRegion = PAD.AbsIntConstant 3 }
              return $ idom' { PAD.absDomVals = vals' }

--- a/src/Pate/Verification/PairGraph/Node.hs
+++ b/src/Pate/Verification/PairGraph/Node.hs
@@ -34,12 +34,9 @@ module Pate.Verification.PairGraph.Node (
 
 import           Prettyprinter ( Pretty(..), sep, (<+>), Doc )
 
-import           Data.Parameterized.Classes
-import           Data.Parameterized.Some
 import qualified Data.Parameterized.TraversableF as TF
 
 import qualified Pate.Arch as PA
-import qualified Pate.Binary as PBi
 import qualified Pate.Block as PB
 import qualified Pate.PatchPair as PPa
 import           Pate.TraceTree

--- a/src/Pate/Verification/PairGraph/Node.hs
+++ b/src/Pate/Verification/PairGraph/Node.hs
@@ -18,7 +18,6 @@ module Pate.Verification.PairGraph.Node (
   , NodeEntry
   , NodeReturn
   , CallingContext
-  , FrozenContext(..)
   , graphNodeCases
   , graphNodeBlocks
   , mkNodeEntry
@@ -30,13 +29,6 @@ module Pate.Verification.PairGraph.Node (
   , nodeFuns
   , returnToEntry
   , functionEntryOf
-  , getFrozen
-  , freezeNode
-  , isThisFrozen
-  , applyFreeze
-  , unfreezeReturn
-  , frozenRepr
-  , freezeNodeFn
   , returnOfEntry
   ) where
 
@@ -87,96 +79,25 @@ graphNodeCases (ReturnNode (NodeReturn _ funs)) = Right funs
 -- | Additional context used to distinguish function calls
 --   "Freezing" one binary in a node indicates that it should not continue
 --   execution until the other binary has returned
-data CallingContext arch = CallingContext { _ctxAncestors :: [PB.BlockPair arch], ctxFrozen :: FrozenContext arch }
+data CallingContext arch = CallingContext { _ctxAncestors :: [PB.BlockPair arch] }
   deriving (Eq, Ord)
 
-data FrozenContext arch where
-  FrozenBlock :: PBi.WhichBinaryRepr bin -> FrozenContext arch
-  FrozenReturn :: PBi.WhichBinaryRepr bin -> FrozenContext arch
-  NotFrozen :: FrozenContext arch
-
-instance Eq (FrozenContext arch) where
-  FrozenBlock repr1 == FrozenBlock repr2 | Just Refl <- testEquality repr1 repr2 = True
-  FrozenReturn repr1 == FrozenReturn repr2 | Just Refl <- testEquality repr1 repr2 = True
-  NotFrozen == NotFrozen = True
-  _ == _ = False
-
-instance Ord (FrozenContext arch) where
-  compare frzn1 frzn2 = case (frzn1, frzn2) of
-    (FrozenBlock repr1, FrozenBlock repr2) -> toOrdering (compareF repr1 repr2)
-    (FrozenBlock{},FrozenReturn{}) -> GT
-    (FrozenBlock{},NotFrozen) -> GT
-
-    (FrozenReturn{}, FrozenBlock{}) -> LT
-    (FrozenReturn repr1, FrozenReturn repr2) -> toOrdering (compareF repr1 repr2)
-    (FrozenReturn{},NotFrozen) -> GT
-
-    (NotFrozen, NotFrozen) -> EQ
-    (NotFrozen, _) -> LT
-
-frozenRepr :: FrozenContext arch -> Maybe (Some PBi.WhichBinaryRepr)
-frozenRepr (FrozenBlock bin) = Just (Some bin)
-frozenRepr (FrozenReturn bin) = Just (Some bin)
-frozenRepr NotFrozen = Nothing
-
-freezeBlock :: PBi.WhichBinaryRepr bin -> CallingContext arch -> CallingContext arch
-freezeBlock bin (CallingContext ctx _) = CallingContext ctx (FrozenBlock bin)
-
-freezeReturnCtx ::  PBi.WhichBinaryRepr bin -> CallingContext arch -> CallingContext arch
-freezeReturnCtx bin (CallingContext ctx _) = CallingContext ctx (FrozenReturn bin)
-
-unfreezeCtx :: CallingContext arch -> CallingContext arch
-unfreezeCtx (CallingContext blks _) = CallingContext blks NotFrozen
 
 instance PA.ValidArch arch => Pretty (CallingContext arch) where
-  pretty (CallingContext bps frzn) =
+  pretty (CallingContext bps) =
     let
       bs = [ pretty bp | bp <- bps ]
-    in sep ((zipWith (<+>) ( "via:" : repeat "<-") bs) ++ case frozenRepr frzn of
-               Just (Some PBi.OriginalRepr) -> ["<<patched>>"]
-               Just (Some PBi.PatchedRepr) -> ["<<original>>"]
-               Nothing -> [])
-
-freezeNodeFn :: PBi.WhichBinaryRepr bin ->  NodeEntry arch -> NodeEntry arch
-freezeNodeFn bin (NodeEntry ctx blks) = NodeEntry (freezeReturnCtx bin ctx) blks
-
-freezeNode :: PBi.WhichBinaryRepr bin -> NodeEntry arch -> NodeEntry arch
-freezeNode bin (NodeEntry ctx blks) = NodeEntry (freezeBlock bin ctx) blks
-
-freezeReturn :: PBi.WhichBinaryRepr bin -> NodeReturn arch -> NodeReturn arch
-freezeReturn bin (NodeReturn ctx fns) = NodeReturn (freezeBlock bin ctx) fns
-
-unfreezeReturn :: NodeReturn arch -> NodeReturn arch
-unfreezeReturn (NodeReturn ctx fns) = NodeReturn (unfreezeCtx ctx) fns
-
-
-getFrozen :: NodeEntry arch -> FrozenContext arch
-getFrozen (NodeEntry ctx _) = ctxFrozen ctx
-
-isThisFrozen :: (forall tp. PPa.PatchPair tp -> tp bin) -> NodeEntry arch -> Bool
-isThisFrozen get node = frozenRepr (getFrozen node) == Just (Some (get PPa.patchPairRepr))
-
-
-applyFreeze ::
-  PBi.WhichBinaryRepr bin ->
-  NodeEntry arch {- ^ current entry point -} ->
-  PPa.PatchPair (PB.ConcreteBlock arch) {- ^ target -} ->
-  NodeEntry arch
-applyFreeze bin (NodeEntry ctx blks) pPair =
-  let
-    blk = PPa.getPair' bin pPair
-    blks' = PPa.setPair bin blk blks
-  in NodeEntry (freezeBlock bin ctx) blks'
+    in sep ((zipWith (<+>) ( "via:" : repeat "<-") bs))
 
 
 rootEntry :: PB.BlockPair arch -> NodeEntry arch
-rootEntry pPair = NodeEntry (CallingContext [] NotFrozen) pPair
+rootEntry pPair = NodeEntry (CallingContext []) pPair
 
 rootReturn :: PB.FunPair arch -> NodeReturn arch
-rootReturn pPair = NodeReturn (CallingContext [] NotFrozen) pPair
+rootReturn pPair = NodeReturn (CallingContext []) pPair
 
 addContext :: PB.BlockPair arch -> NodeEntry arch -> NodeEntry arch
-addContext newCtx (NodeEntry (CallingContext ctx frzn) blks) = NodeEntry (CallingContext (newCtx:ctx) frzn) blks
+addContext newCtx (NodeEntry (CallingContext ctx) blks) = NodeEntry (CallingContext (newCtx:ctx)) blks
 
 mkNodeEntry :: NodeEntry arch -> PB.BlockPair arch -> NodeEntry arch
 mkNodeEntry node pPair = NodeEntry (graphNodeContext node) pPair
@@ -206,14 +127,14 @@ instance PA.ValidArch arch => Show (NodeEntry arch) where
 instance PA.ValidArch arch => Pretty (NodeEntry arch) where
   pretty e = case functionEntryOf e == e of
     True -> case graphNodeContext e of
-      CallingContext [] _ -> pretty (nodeBlocks e)
+      CallingContext [] -> pretty (nodeBlocks e)
       _ -> pretty (nodeBlocks e) <+> "[" <+> pretty (graphNodeContext e) <+> "]"
     False -> PPa.ppPatchPair' PB.ppBlockAddr (nodeBlocks e)
       <+> "[" <+> pretty (graphNodeContext (addContext (nodeBlocks (functionEntryOf e)) e)) <+> "]"
 
 instance PA.ValidArch arch => Pretty (NodeReturn arch) where
   pretty e = case returnNodeContext e of
-    CallingContext [] _ -> pretty (nodeFuns e)
+    CallingContext [] -> pretty (nodeFuns e)
     _ -> pretty (nodeFuns e) <+> "[" <+> pretty (returnNodeContext e) <+> "]"
 
 instance PA.ValidArch arch => Show (NodeReturn arch) where

--- a/src/Pate/Verification/PairGraph/Node.hs
+++ b/src/Pate/Verification/PairGraph/Node.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -18,7 +19,8 @@ module Pate.Verification.PairGraph.Node (
   , NodeEntry
   , NodeReturn
   , CallingContext
-  , graphNodeCases
+  , pattern GraphNodeEntry
+  , pattern GraphNodeReturn
   , graphNodeBlocks
   , mkNodeEntry
   , addContext
@@ -69,9 +71,14 @@ graphNodeBlocks :: GraphNode arch -> PB.BlockPair arch
 graphNodeBlocks (GraphNode ne) = nodeBlocks ne
 graphNodeBlocks (ReturnNode ret) = TF.fmapF PB.functionEntryToConcreteBlock (nodeFuns ret)
 
-graphNodeCases :: GraphNode arch -> Either (PB.BlockPair arch) (PB.FunPair arch)
-graphNodeCases (GraphNode (NodeEntry _ blks)) = Left blks
-graphNodeCases (ReturnNode (NodeReturn _ funs)) = Right funs
+
+pattern GraphNodeEntry :: PB.BlockPair arch -> GraphNode arch
+pattern GraphNodeEntry blks <- (GraphNode (NodeEntry _ blks))
+
+pattern GraphNodeReturn :: PB.FunPair arch -> GraphNode arch
+pattern GraphNodeReturn blks <- (ReturnNode (NodeReturn _ blks))
+
+{-# COMPLETE GraphNodeEntry, GraphNodeReturn #-}
 
 -- | Additional context used to distinguish function calls
 --   "Freezing" one binary in a node indicates that it should not continue

--- a/tests/TestBase.hs
+++ b/tests/TestBase.hs
@@ -31,6 +31,7 @@ import qualified Pate.Event as PE
 import qualified Pate.Loader as PL
 import qualified Pate.Loader.ELF as PLE
 import qualified Pate.Equivalence.Error as PEE
+import qualified Pate.PatchPair as PPa
 
 data TestConfig where
   TestConfig ::
@@ -146,10 +147,10 @@ doTest mwb cfg sv fp = do
               PE.Warning err -> do
                 addLogMsg $ "WARNING: " ++ show err
               PE.ErrorRaised err -> putStrLn $ "Error: " ++ show err
-              PE.ProofTraceEvent _ oAddr pAddr msg _ -> do
-                let addr = case oAddr == pAddr of
-                      True -> show oAddr
-                      False -> "(" ++ show oAddr ++ "," ++ show pAddr ++ ")"
+              PE.ProofTraceEvent _ addrPair msg _ -> do
+                let addr = case addrPair of
+                      PPa.PatchPairC oAddr pAddr | oAddr == pAddr -> "(" ++ show oAddr ++ "," ++ show pAddr ++ ")"
+                      _ -> show (PPa.some addrPair)
                 addLogMsg $ addr ++ ":" ++ show msg
               PE.StrongestPostDesync pPair _ ->
                 addLogMsg $ "Desync at: " ++ show pPair

--- a/tools/pate/Main.hs
+++ b/tools/pate/Main.hs
@@ -51,6 +51,7 @@ import qualified Pate.Solver as PS
 import qualified Pate.Timeout as PTi
 import qualified Pate.Verbosity as PV
 import qualified Pate.Verification.StrongestPosts.CounterExample as PVSC
+import qualified Pate.PatchPair as PPa
 
 import qualified Pate.ArchLoader as PAL
 
@@ -338,8 +339,8 @@ terminalFormatEvent evt =
     PE.FunctionsDiscoveredFromHints _ extraAddrs ->
       layout ("Additional functions discovered based on hits: " <> PP.line
              <> PP.vcat (map PP.viaShow extraAddrs) <> PP.line)
-    PE.ProofTraceEvent _stack origAddr _patchedAddr msg _tm ->
-      layout (PP.pretty origAddr <> ": " <> PP.pretty msg <> PP.line)
+    PE.ProofTraceEvent _stack addrPair msg _tm ->
+      layout (PPa.ppPatchPairC PP.pretty addrPair <> ": " <> PP.pretty msg <> PP.line)
     PE.ProofTraceFormulaEvent _stk origAddr _patchedAddr _sym expr _tm ->
       layout (PP.pretty origAddr <> ": " <> WI.printSymExpr expr <> PP.line)
     PE.StrongestPostOverallResult status _ ->

--- a/tools/pate/Main.hs
+++ b/tools/pate/Main.hs
@@ -51,7 +51,6 @@ import qualified Pate.Solver as PS
 import qualified Pate.Timeout as PTi
 import qualified Pate.Verbosity as PV
 import qualified Pate.Verification.StrongestPosts.CounterExample as PVSC
-import qualified Pate.PatchPair as PPa
 
 import qualified Pate.ArchLoader as PAL
 


### PR DESCRIPTION
Resolves issue #342 

Adds an additional constructor to 'PatchPair' to support singletons, and adds several interface functions to allow interacting with PatchPairs while be agnostic of singleton vs. pair PatchPairs.

In non-trivial cases (i.e. in top-level equivalence analysis functions), providing singleton PatchPairs will result in a runtime error. Currently no singleton PatchPair values are produced anywhere, but once they are in use those functions will require proper implementations in order to handle singletons.

