### PR TITLE
Push docker containers to Artifactory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ name: CI Matrix
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, dwest/test-docker]
 
 jobs:
   docker:
@@ -34,6 +34,19 @@ jobs:
         run: |
           docker run --rm -itd --entrypoint bash --name pate -v `pwd`/tests/aarch32:/tests pate
           (echo "cabal run pate-test-aarch32 -- -p args-equal") | script -q /dev/null docker attach pate
+
+      - name: Artifactory Login
+        uses: docker/login-action@v2
+        with:
+          registry: artifactory.galois.com:5025
+          username: ${{ secrets.ARTIFACTORY_USER }}
+          password: ${{ secrets.ARTIFACTORY_KEY }}
+
+      - name: Push Docker image
+        run: |
+          CI_COMMIT_SHORT_SHA=$(git rev-parse --short $GITHUB_SHA)
+          docker tag pate artifactory.galois.com:5025/pate/pate:$CI_COMMIT_SHORT_SHA
+          docker push artifactory.galois.com:5025/pate/pate:$CI_COMMIT_SHORT_SHA
 
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Reference Ticket #2868

I generated an Access Token that will allow the actions build to push docker containers to the `pate_docker-local`
repository on Artifactory. This token has been stored in the Github secrets, that can be accessed from the CI job.

$ARTIFACTORY_USER: This is just the tokens name (pate_ci)
$ARTIFACTORY_KEY: This is the actual access token that was generated

For the tag, Github only has built-in support for the long version of the commit hash. I went ahead and added a step to convert it to the short version, which should make it easier to read and reference. So now, you can pull the pate images from the following:

artifactory.galois.com:5025/pate/pate:$CI_COMMIT_SHORT_SHA

I standardized on the Gitlab naming convention of "$CI_COMMIT_SHORT_SHA" for the SHORT_SHA. If you think that SHORT_SHA will be problematic for any reason, let me know and I can switch it back to the $GITHUB_SHA.

It looks like it successfully finished and the container appears to be here:

[https://artifactory.galois.com:443/artifactory/pate_docker-local/pate/pate/496fa37/](https://artifactory.galois.com/artifactory/pate_docker-local/pate/pate/496fa37/)

Can I have you confirm that everything looks correct to you?