### PR TITLE
binja: explicitly specify expected platform for pate container

### DIFF
--- a/pate_binja/run-pate.sh
+++ b/pate_binja/run-pate.sh
@@ -5,7 +5,7 @@ if [ "$PATE_BINJA_MODE" = "BUILD" ]
 then
     pate="$PATE/pate.sh"
 else
-    pate="docker run --rm -i -v .:/work --workdir=/work pate"
+    pate="docker run --platform linux/amd64 --rm -i -v .:/work --workdir=/work pate"
 fi
 
 exec $pate "$@"


### PR DESCRIPTION
Match platform in Dockerfile, avoid platform mismatch warning on non-native platforms (e.g. arm64 macs)