### PR TITLE
Dm/traceconstraints

### DIFF
--- a/pate.cabal
+++ b/pate.cabal
@@ -161,6 +161,7 @@ library
                        Pate.Script,
                        Pate.Timeout,
                        Pate.TraceTree,
+                       Pate.TraceConstraint,
                        Pate.ExprMappable,
                        What4.ExprHelpers,
                        What4.PathCondition,

--- a/src/Pate/CLI.hs
+++ b/src/Pate/CLI.hs
@@ -97,6 +97,7 @@ mkRunConfig archLoader opts rcfg mtt = let
         , PC.cfgStackScopeAssume = not $ noAssumeStackScope opts
         , PC.cfgIgnoreWarnings = ignoreWarnings opts
         , PC.cfgAlwaysClassifyReturn = alwaysClassifyReturn opts
+        , PC.cfgTraceConstraints = traceConstraints opts
         }
     cfg = PL.RunConfig
         { PL.archLoader = archLoader
@@ -150,6 +151,7 @@ data CLIOptions = CLIOptions
   , ignoreWarnings :: [String]
   , alwaysClassifyReturn :: Bool
   , preferTextInput :: Bool
+  , traceConstraints :: Bool
   } deriving (Eq, Ord, Show)
 
 printAtVerbosity
@@ -474,4 +476,8 @@ cliOptions = OA.info (OA.helper <*> parser)
     <*> OA.switch
          ( OA.long "prefer-text-input"
          <> OA.help "Prefer taking text input over multiple choice menus where possible."
+         )
+    <*> OA.switch
+         ( OA.long "add-trace-constraints"
+         <> OA.help "Prompt to add additional constraints when generating traces."
          )

--- a/src/Pate/Config.hs
+++ b/src/Pate/Config.hs
@@ -290,6 +290,8 @@ data VerificationConfig validRepr =
     , cfgPreferTextInput :: Bool
     -- ^ modifies some menus to take string input instead of providing
     -- a menu selection
+    , cfgTraceConstraints :: Bool
+    -- ^ flag to determine if the user should be prompted to add constraints to traces
     }
 
 
@@ -317,4 +319,5 @@ defaultVerificationCfg =
                      , cfgIgnoreWarnings = []
                      , cfgAlwaysClassifyReturn = False
                      , cfgPreferTextInput = False
+                     , cfgTraceConstraints = False
                      }

--- a/src/Pate/PatchPair.hs
+++ b/src/Pate/PatchPair.hs
@@ -617,7 +617,7 @@ instance W4S.W4SerializableF sym f => W4S.W4Serializable sym (PatchPair f) where
 
 
 instance (forall bin. PB.KnownBinary bin => W4Deserializable sym (f bin)) => W4Deserializable sym (PatchPair f) where
-  w4Deserialize v = do
+  w4Deserialize_ v = do
     JSON.Object o <- return v
     let
       case_pair = do

--- a/src/Pate/PatchPair.hs
+++ b/src/Pate/PatchPair.hs
@@ -101,6 +101,7 @@ import qualified What4.JSON as W4S
 import What4.JSON
 import Control.Monad.State.Strict (StateT (..), put)
 import qualified Control.Monad.State.Strict as CMS
+import           Control.Applicative ( (<|>) )
 
 -- | A pair of values indexed based on which binary they are associated with (either the
 --   original binary or the patched binary).
@@ -613,3 +614,20 @@ w4SerializePair ppair f = case ppair of
 
 instance W4S.W4SerializableF sym f => W4S.W4Serializable sym (PatchPair f) where
   w4Serialize ppair = w4SerializePair ppair w4SerializeF
+
+
+instance (forall bin. PB.KnownBinary bin => W4Deserializable sym (f bin)) => W4Deserializable sym (PatchPair f) where
+  w4Deserialize v = do
+    JSON.Object o <- return v
+    let
+      case_pair = do
+        (vo :: f PB.Original) <- o .: "original"
+        (vp :: f PB.Patched) <- o .: "patched"
+        return $ PatchPair vo vp
+      case_orig = do
+        (vo :: f PB.Original) <- o .: "original"
+        return $ PatchPairOriginal vo
+      case_patched = do
+        (vp :: f PB.Patched) <- o .: "patched"
+        return $ PatchPairPatched vp
+    case_pair <|> case_orig <|> case_patched

--- a/src/Pate/TraceConstraint.hs
+++ b/src/Pate/TraceConstraint.hs
@@ -1,0 +1,178 @@
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE GADTs #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Pate.TraceConstraint
+  (
+    TraceConstraint(..)
+  , readDeserializable
+  , constraintToPred
+  , TraceConstraintMap(..)
+  , readConstraintMap
+  ) where
+
+import           Prelude hiding (EQ)
+
+import qualified Control.Monad.IO.Unlift as IO
+import           Control.Monad ( forM )
+import           Control.Monad.Except
+import           Control.Monad.Trans
+import qualified Data.Aeson as JSON
+import qualified Data.Aeson.Types as JSON
+
+import qualified Data.Text.Lazy.Encoding as Text
+import qualified Data.Text.Encoding.Error as Text
+import qualified Data.Kind as DK
+import           Data.String
+import           Data.Map ( Map )
+import qualified Data.Map as Map
+
+import qualified Prettyprinter as PP
+
+import qualified What4.Interface as W4
+import qualified What4.Concrete as W4
+
+import qualified Pate.Arch as PA
+import qualified Pate.PatchPair as PPa
+import           Pate.Verification.PairGraph.Node
+import           Pate.TraceTree
+import qualified What4.JSON as W4S
+import           What4.JSON ( (.:) )
+import           Data.Parameterized.Some (Some(..))
+import qualified Data.BitVector.Sized as BVS
+import qualified Numeric as Num
+
+newtype TraceIdentifier = TraceIdentifier String
+  deriving (Eq, Ord, IsString)
+
+data ConstraintOp = LTs | LTu | GTs | GTu | LEs | LEu | GEs | GEu | NEQ | EQ
+  deriving (Show, Read)
+
+data TraceConstraint sym = forall tp. TraceConstraint 
+  { tcVar :: W4.SymExpr sym tp
+  , tcOp :: ConstraintOp
+  , tcConst :: W4.ConcreteVal tp 
+  }
+
+instance forall sym. W4S.W4Deserializable sym (TraceConstraint sym) where
+  w4Deserialize_ v | W4S.SymDeserializable{} <- W4S.symDeserializable @sym  = do
+    JSON.Object o <- return v
+    (Some (var :: W4.SymExpr sym tp)) <- o .: "var"
+    (opJSON :: JSON.Value) <- o .: "op"
+    (op :: ConstraintOp) <- W4S.readJSON opJSON
+    case W4.exprType var of
+      W4.BaseBVRepr w -> do
+        (cS :: String) <- o .: "const"
+        ((c :: Integer),""):_ <- return $ Num.readDec cS
+        case (BVS.mkBVUnsigned w c) of
+          Just bv -> return $ TraceConstraint var op (W4.ConcreteBV w bv)
+          Nothing -> fail "Unexpected integer size"
+      _ -> fail "Unsupported expression type"
+
+{-
+instance forall sym arch. IsTraceNode '(sym :: DK.Type,arch) "trace_constraint" where
+  type TraceNodeType '(sym,arch) "trace_constraint" = TraceConstraint sym
+  prettyNode _ _ = PP.pretty ("TODO" :: String)
+  nodeTags = mkTags @'(sym,arch) @"trace_constraint" [Summary, Simplified]
+-}
+
+constraintToPred ::
+  forall sym.
+  W4.IsExprBuilder sym =>
+  sym ->
+  TraceConstraint sym -> 
+  IO (W4.Pred sym)
+constraintToPred sym (TraceConstraint var op c) = case W4.exprType var of
+  W4.BaseBVRepr w -> do
+    let W4.ConcreteBV _ bv = c
+    bvSym <- W4.bvLit sym w bv
+    let go :: (forall w. 1 W4.<= w => sym -> W4.SymBV sym w -> W4.SymBV sym w -> IO (W4.Pred sym)) -> IO (W4.Pred sym)
+        go f = f sym var bvSym
+    case op of
+      LTs -> go W4.bvSlt
+      LTu -> go W4.bvUlt
+      LEs -> go W4.bvSle
+      LEu -> go W4.bvUle
+      EQ -> go W4.isEq
+      _ -> fail "err"
+
+  _ -> fail "Unexpected constraint "
+
+
+
+newtype TraceConstraintMap sym arch = 
+  TraceConstraintMap (Map (GraphNode arch) (TraceConstraint sym))
+
+
+instance forall sym arch. IsTraceNode '(sym :: DK.Type,arch :: DK.Type) "trace_constraint_map" where
+  type TraceNodeType '(sym,arch) "trace_constraint_map" = TraceConstraintMap sym arch
+  prettyNode _ _ = PP.pretty ("TODO" :: String)
+  nodeTags = mkTags @'(sym,arch) @"trace_constraint_map" [Summary, Simplified]
+
+readConstraintMap ::
+  W4.IsExprBuilder sym =>
+  IsTreeBuilder '(sym,arch) e m =>
+  IO.MonadUnliftIO m =>
+  PA.ValidArch arch =>
+  sym ->
+  String {- ^ input prompt -} ->
+  [(GraphNode arch,W4S.ExprEnv sym)] ->
+  m (TraceConstraintMap sym arch)
+readConstraintMap sym msg ndEnvs = do
+  let parse s = case JSON.eitherDecode (fromString s) of
+        Left err -> return $ Left $ InputChoiceError "Failed to decode JSON" [err]
+        Right (v :: JSON.Value) -> runExceptT $ do
+          nodes <- runJSON $ do
+            JSON.Object o <- return v
+            (nodes :: [JSON.Value]) <- o JSON..: "trace_constraints"
+            return nodes
+          let nds = zip ndEnvs nodes
+          fmap (TraceConstraintMap . Map.fromList) $ forM nds $ \((nd, env), constraint_json) -> do
+             (lift $ W4S.jsonToW4 sym env constraint_json) >>= \case
+               Left err -> throwError $ InputChoiceError "Failed to parse value" [err]
+               Right a -> return (nd, a)
+  chooseInput_ @"trace_constraint_map" msg parse >>= \case
+    Nothing -> IO.liftIO $ fail "Unexpected trace map read"
+    Just a -> return a
+
+
+runJSON :: JSON.Parser a -> ExceptT InputChoiceError IO a
+runJSON p = ExceptT $ case JSON.parse (\() -> p) () of
+  JSON.Success a -> return $ Right a
+  JSON.Error err -> return $ Left $ InputChoiceError "Failed to parse value" [err]
+
+
+
+-- FIXME: Move
+readDeserializable ::
+  forall nm_choice sym k e m.
+  W4S.W4Deserializable sym (TraceNodeLabel nm_choice, TraceNodeType k nm_choice) =>
+  W4.IsExprBuilder sym =>
+  IsTreeBuilder k e m =>
+  IsTraceNode k nm_choice =>
+  IO.MonadUnliftIO m =>
+  sym ->
+  W4S.ExprEnv sym ->
+  String ->
+  m (Maybe (TraceNodeLabel nm_choice, TraceNodeType k nm_choice))
+readDeserializable sym env msg = do
+  let parse s = case JSON.eitherDecode (fromString s) of
+        Left err -> return $ Left $ InputChoiceError "Failed to decode JSON" [err]
+        Right (v :: JSON.Value) -> W4S.jsonToW4 sym env v >>= \case
+          Left err -> return $ Left $ InputChoiceError "Failed to parse value" [err]
+          Right a -> return $ Right a
+  chooseInput @nm_choice msg parse

--- a/src/Pate/Verification/StrongestPosts.hs
+++ b/src/Pate/Verification/StrongestPosts.hs
@@ -109,6 +109,7 @@ import qualified Pate.SimulatorRegisters as PSR
 import qualified Pate.Verification.StrongestPosts.CounterExample as CE
 import qualified Pate.Register.Traversal as PRt
 import           Pate.Discovery.PLT (extraJumpClassifier, ExtraJumps(..), ExtraJumpTarget(..))
+import qualified Pate.TraceConstraint as PTC
 
 import           Pate.TraceTree
 import qualified Pate.Verification.Validity as PVV
@@ -860,37 +861,104 @@ clearTrivialCondition nd condK pg = case getCondition pg nd ConditionEquiv of
     return pg1
   Nothing -> return pg
 
-showFinalResult :: PairGraph sym arch -> EquivM sym arch ()
+-- | Context needed to re-generate traces when adding trace constraints
+data IntermediateEqCond sym arch v = 
+  IntermediateEqCond
+    { ieqBundle :: SimBundle sym arch v
+    , ieqFootprints:: PPa.PatchPairC (CE.TraceFootprint sym arch)
+    , ieqEnv :: W4S.ExprEnv sym
+    , ieqAsms :: PAS.AssumptionSet sym
+    , ieqCond :: W4.Pred sym
+    , ieqDom :: AbstractDomain sym arch v
+    }
+
+data EqCondCollector sym arch = EqCondCollector
+  { eqCondFinals :: Map.Map (GraphNode arch) (FinalEquivCond sym arch)
+  , eqCondInterims :: Map.Map (GraphNode arch) (PS.SimSpec sym arch (IntermediateEqCond sym arch))
+  , eqCondConstraints :: PTC.TraceConstraintMap sym arch
+  }
+
+getExprEnvs :: EqCondCollector sym arch -> Map.Map (GraphNode arch) (W4S.ExprEnv sym)
+getExprEnvs st = fmap (\spec -> PS.viewSpecBody spec ieqEnv) (eqCondInterims st)
+
+showFinalResult :: forall sym arch. PairGraph sym arch -> EquivM sym arch ()
 showFinalResult pg0 = withTracing @"final_result" () $ withSym $ \sym -> do
-  subTree @"node" "Observable Counter-examples" $ do
-    forM_ (Map.toList (pairGraphObservableReports pg0)) $ \(nd,report) -> 
-      subTrace (GraphNode nd) $ 
-        emitTrace @"observable_result" (CE.ObservableCheckCounterexample report)
-  eq_conds <- fmap catMaybes $ subTree @"node" "Assumed Equivalence Conditions" $ do
-    
-    forM (getAllNodes pg0) $ \nd -> do
+  st <- go (EqCondCollector Map.empty Map.empty (PTC.TraceConstraintMap Map.empty))
+  add_constraints <- asks (PCfg.cfgTraceConstraints . envConfig)
+  case add_constraints of
+    True -> 
+      let loop st_ = chooseBool "Regenerate result with new trace constraints?" >>= \case
+            True -> do
+              tcs <- PTC.readConstraintMap sym "Waiting for constraints.." (getExprEnvs st_)
+              go (st_ {eqCondConstraints = tcs}) >>= loop
+            False -> return ()
+      in loop st
+    False -> return ()
+
+  where
+    mkEqCond ::
+      EqCondCollector sym arch ->
+      GraphNode arch -> 
+      NodeBuilderT '(sym,arch) "node" (EquivM_ sym arch) (EqCondCollector sym arch)
+    mkEqCond rs nd  = do
       pg <- lift $ clearTrivialCondition nd ConditionEquiv pg0
-      case getCondition pg nd ConditionEquiv of
-        Just cond_spec -> subTrace nd $ do
-          s <- withFreshScope (graphNodeBlocks nd) $ \scope -> do
-            (_,cond) <- IO.liftIO $ PS.bindSpec sym (PS.scopeVarsPair scope) cond_spec
-            (tr, _) <- withGraphNode scope nd pg $ \bundle d -> do
-              cond_simplified <- PSi.applySimpStrategy PSi.deepPredicateSimplifier cond
-              eqCond_pred <- PEC.toPred sym cond_simplified
-              (mtraceT, mtraceF) <- getTracesForPred scope bundle d eqCond_pred
-              case (mtraceT, mtraceF) of
-                (Just traceT, Just traceF) -> do
-                  cond_pretty <- PSi.applySimpStrategy PSi.prettySimplifier eqCond_pred
-                  return $ (Just (FinalEquivCond cond_pretty traceT traceF), pg)
-                _ -> return (Nothing, pg)
-            return $ (Const (fmap (nd,) tr))
-          return $ PS.viewSpec s (\_ -> getConst)
-        Nothing -> return Nothing
-  let result = pairGraphComputeVerdict pg0
-  emitTrace @"equivalence_result" result
-  let eq_conds_map = Map.fromList eq_conds
-  let toplevel_result = FinalResult result (pairGraphObservableReports pg0) eq_conds_map
-  emitTrace @"toplevel_result" toplevel_result
+      let PTC.TraceConstraintMap tcm = eqCondConstraints rs
+
+      
+      let
+        rest :: forall v. PS.SimScope sym arch v -> IntermediateEqCond sym arch v -> EquivM_ sym arch (Maybe (FinalEquivCond sym arch))
+        rest scope (IntermediateEqCond bundle fps _ _ cond d) =  withSym $ \sym -> do
+          trace_constraint <- case Map.lookup nd tcm of
+            Just tc -> IO.liftIO $ PTC.constraintToPred sym tc
+            Nothing -> return $ W4.truePred sym
+          mres <- withSatAssumption (PAS.fromPred trace_constraint) $ do
+            (mtraceT, mtraceF) <- getTracesForPred scope bundle d cond
+            case (mtraceT, mtraceF) of
+              (Just traceT, Just traceF) -> do
+                cond_pretty <- PSi.applySimpStrategy PSi.prettySimplifier cond
+                return $ Just (FinalEquivCond cond_pretty traceT traceF fps)
+              _ -> return Nothing
+          case mres of
+            Just res -> return res
+            Nothing -> emitWarning PEE.UnsatisfiableAssumptions >> return Nothing
+
+      case Map.lookup nd (eqCondInterims rs) of
+        Just ieqcspec -> subTrace nd $ PS.viewSpec ieqcspec $ \scope ieqc -> withAssumptionSet (ieqAsms ieqc) $ do
+          rest scope ieqc >>= \case
+            Just fcond -> return (rs { eqCondFinals = Map.insert nd fcond (eqCondFinals rs) })
+            Nothing -> return rs
+        Nothing -> case getCondition pg nd ConditionEquiv of
+          Just cond_spec -> subTrace nd $ withSym $ \sym -> do
+            spec <- withFreshScope (graphNodeBlocks nd) $ \scope -> fmap PS.WithScope $ do
+              (_,cond) <- IO.liftIO $ PS.bindSpec sym (PS.scopeVarsPair scope) cond_spec
+              fmap fst $ withGraphNode scope nd pg $ \bundle d -> do
+                cond_simplified <- PSi.applySimpStrategy PSi.deepPredicateSimplifier cond
+                eqCond_pred <- PEC.toPred sym cond_simplified
+                (fps, eenv) <- getTraceFootprint scope bundle
+                asms <- currentAsm
+                let ieqc = IntermediateEqCond bundle fps eenv asms eqCond_pred d 
+                let interims = Map.insert nd (PS.mkSimSpec scope ieqc) (eqCondInterims rs)
+                rest scope ieqc >>= \case
+                  Just fcond -> return (rs { eqCondFinals = Map.insert nd fcond (eqCondFinals rs), eqCondInterims = interims }, pg)
+                  Nothing -> return (rs { eqCondInterims = interims }, pg)
+            return $ PS.viewSpecBody spec PS.unWS
+          Nothing -> return rs
+
+    go :: EqCondCollector sym arch -> EquivM sym arch (EqCondCollector sym arch)
+    go rs = do
+        subTree @"node" "Observable Counter-examples" $ do
+          forM_ (Map.toList (pairGraphObservableReports pg0)) $ \(nd,report) -> 
+            subTrace (GraphNode nd) $ 
+              emitTrace @"observable_result" (CE.ObservableCheckCounterexample report)
+        
+        rs' <- subTree @"node" "Assumed Equivalence Conditions" $ 
+          foldM mkEqCond (rs { eqCondFinals = Map.empty }) (getAllNodes pg0)
+        let result = pairGraphComputeVerdict pg0
+        emitTrace @"equivalence_result" result
+
+        let toplevel_result = FinalResult result (pairGraphObservableReports pg0) (eqCondFinals rs')
+        emitTrace @"toplevel_result" toplevel_result
+        return rs'
 
 data FinalResult sym arch = FinalResult
   { 
@@ -904,6 +972,7 @@ data FinalEquivCond sym arch = FinalEquivCond
     _finEqCondPred :: W4.Pred sym
   , _finEqCondTraceTrue :: CE.TraceEvents sym arch
   , _finEqCondTraceFalse :: CE.TraceEvents sym arch
+  , _finEqFootprints :: PPa.PatchPairC (CE.TraceFootprint sym arch)
   }
 
 
@@ -915,8 +984,8 @@ instance (PA.ValidArch arch, PSo.ValidSym sym) => W4S.W4Serializable sym (FinalR
     W4S.object [ "eq_status" W4S..= st, "observable_counterexamples" W4S..= obs, "eq_conditions" W4S..= conds ]
 
 instance (PA.ValidArch arch, PSo.ValidSym sym) => W4S.W4Serializable sym (FinalEquivCond sym arch) where
-  w4Serialize (FinalEquivCond p trT trF) = do
-    W4S.object [ "predicate" W4S..== p, "trace_true" W4S..= trT, "trace_false" W4S..= trF ]
+  w4Serialize (FinalEquivCond p trT trF fps) = do
+    W4S.object [ "predicate" W4S..== p, "trace_true" W4S..= trT, "trace_false" W4S..= trF, "trace_footprint" W4S..= fps ]
 
 
 instance (PSo.ValidSym sym, PA.ValidArch arch) => IsTraceNode '(sym,arch) "toplevel_result" where

--- a/src/Pate/Verification/StrongestPosts.hs
+++ b/src/Pate/Verification/StrongestPosts.hs
@@ -889,7 +889,7 @@ showFinalResult pg0 = withTracing @"final_result" () $ withSym $ \sym -> do
     True -> 
       let loop st_ = chooseBool "Regenerate result with new trace constraints?" >>= \case
             True -> do
-              tcs <- PTC.readConstraintMap sym "Waiting for constraints.." (getExprEnvs st_)
+              tcs <- PTC.readConstraintMap sym "Waiting for constraints.." (Map.toAscList (getExprEnvs st_))
               go (st_ {eqCondConstraints = tcs}) >>= loop
             False -> return ()
       in loop st

--- a/src/Pate/Verification/Widening.hs
+++ b/src/Pate/Verification/Widening.hs
@@ -56,6 +56,8 @@ import           Data.Parameterized.Classes()
 import           Data.Parameterized.NatRepr
 import           Data.Parameterized.Some
 import qualified Data.Parameterized.Map as MapF
+import qualified Data.Text.Lazy.Encoding as Text
+import qualified Data.Text.Encoding.Error as Text
 
 import qualified What4.Interface as W4
 import qualified What4.Expr.Builder as W4B
@@ -547,7 +549,7 @@ getTraceConstraint scope bundle = withSym $ \sym -> do
 instance (PSo.ValidSym sym, PA.ValidArch arch) => IsTraceNode '(sym,arch) "trace_footprint" where
   type TraceNodeType '(sym,arch) "trace_footprint" = CE.TraceFootprint sym arch
   type TraceNodeLabel "trace_footprint" = JSON.Value
-  prettyNode json _ = PP.viaShow json
+  prettyNode json _ = PP.pretty $ Text.decodeUtf8With Text.lenientDecode $ JSON.encode json
   nodeTags = [(Summary, \_ _ -> "TODO"), (Simplified, \_ _ -> "TODO")]
   jsonNode _ json _ = return json
 

--- a/src/What4/JSON.hs
+++ b/src/What4/JSON.hs
@@ -24,6 +24,7 @@ module What4.JSON
   , W4SerializableFC
   , SerializableExprs
   , w4ToJSON
+  , w4ToJSONEnv
   , object
   , w4SerializeString
   , (.=)

--- a/tests/integration/packet/packet.exp
+++ b/tests/integration/packet/packet.exp
@@ -18,7 +18,7 @@
 # Also note this example is mentioned in the README.rst and used in the User Manual.
 # Major changes here likely warrant an update of the corresponding User Manual content.
 
-spawn ./pate.sh --original tests/integration/packet/exe/packet.exe --patched tests/integration/packet/exe/packet.patched.exe -s parse_packet
+spawn ./pate.sh --original tests/integration/packet/exe/packet.exe --patched tests/integration/packet/exe/packet.patched.exe -s parse_packet --add-trace-constraints
 
 set timeout 480
 
@@ -42,6 +42,17 @@ expect "0: Finish and view final result"
 expect "?>"
 send "0\r"
 
+expect "Regenerate result with new trace constraints?"
+expect "0: True"
+send "0\r"
+expect "Waiting for constraints.."
+send "input \"\[ \[ { \\\"var\\\" : { \\\"symbolic_ident\\\" : -6 }, \\\"op\\\" : \\\"NEQ\\\", \\\"const\\\" : \\\"128\\\"} \] \]\"\r"
+
+expect "Regenerate result with new trace constraints?"
+expect "1: False"
+send "1\r"
+
+
 expect "15: Final Result"
 expect ">"
 send "15\r"
@@ -51,19 +62,38 @@ expect "2: Binaries are conditionally, observably equivalent"
 expect ">"
 send "0\r"
 
+
+
 # Inspect the specific equivalence condition
 
 expect "0: segment1+0x644 \\\[ via: \"parse_packet\" (segment1+0x554) \\\]"
 expect ">"
 send "0\r"
 
-expect "3: let -- segment1+0x664.. in not v40591"
+expect -re {3: let -- segment1\+0x664.. in not v(\d)+}
 expect ">"
 send "3\r"
 
-expect "v40591 = and (eq 0x80:\\\[8\\\] v40584) (not (eq v40587 (bvSum v40584 0x80:\\\[8\\\])))"
-expect "in not v40591"
+expect -re {v((\d)+) = and \(eq 0x80:\[8\] v((\d)+)\) \(not \(eq v((\d)+) \(bvSum v((\d)+) 0x80:\[8\]\)\)\)}
+expect -re {in not v((\d)+)}
 expect ">"
+
+send "up\r"
+expect ">"
+send "up\r"
+expect ">"
+send "up\r"
+expect "5: Assumed Equivalence Conditions"
+expect ">"
+send "5\r"
+
+expect "0: segment1+0x644 \\\[ via: \"parse_packet\" (segment1+0x554) \\\]"
+expect ">"
+send "0\r"
+
+# constraint has made the equivalence condition satisified
+expect "0: true"
+
 send "\x04" ; # Ctrl-D (EOF)
 
 # remove EOF from expect_before, now that we're expecting it


### PR DESCRIPTION
support additional constraints when generating traces

* add `--add-trace-constraints` flag that allows for generating additional traces with constraints for the final equivalence conditions
  - Defines a trace constraint datatype in Pate.TraceConstraint that is simply: expression, comparison, constant
* add alternative what4 serializer that uses expression identifiers (based on what4 hashes/nonces) in lieu of serialized expressions
* add deserialization infrastructure for expressions-containing types, using the expression environment from the identifier-based serializer