### PR TITLE
add ExprFoldable class that doesn't rely on IO

### DIFF
--- a/arch/Pate/AArch32.hs
+++ b/arch/Pate/AArch32.hs
@@ -57,6 +57,7 @@ import qualified Language.ASL.Globals as ASL
 import qualified Pate.Arch as PA
 import qualified Pate.Block as PB
 import qualified Pate.Discovery.PLT as PLT
+import qualified Pate.ExprMappable as PEM
 import qualified Pate.Equivalence.Error as PEE
 import qualified Pate.Equivalence.RegisterDomain as PER
 import qualified Pate.Equivalence.EquivalenceDomain as PED
@@ -123,6 +124,12 @@ instance W4S.W4Serializable sym (ARMReg.ARMReg tp) where
 
 instance W4S.W4SerializableF sym ARMReg.ARMReg where
 instance (W4S.W4SerializableFC ARMReg.ARMReg) where
+
+instance PEM.ExprFoldable sym (ARMReg.ARMReg tp) where
+  foldExpr _ _ _ = return
+
+instance PEM.ExprFoldableF sym ARMReg.ARMReg where
+instance (PEM.ExprFoldableFC ARMReg.ARMReg) where
 
 instance PA.ValidArch SA.AArch32 where
   type ArchConfigOpts SA.AArch32 = AArch32Opts SA.AArch32

--- a/arch/Pate/PPC.hs
+++ b/arch/Pate/PPC.hs
@@ -69,6 +69,7 @@ import qualified Pate.Binary as PB
 import qualified Pate.Block as PBl
 import qualified Pate.Discovery as PD
 import qualified Pate.Discovery.PLT as PLT
+import qualified Pate.ExprMappable as PEM
 import qualified Pate.Equivalence.Error as PEE
 import qualified Pate.Equivalence.RegisterDomain as PER
 import qualified Pate.Equivalence.EquivalenceDomain as PED
@@ -171,6 +172,12 @@ instance forall v sym tp. SP.KnownVariant v => W4S.W4Serializable sym (PPC.PPCRe
 
 instance SP.KnownVariant v => W4S.W4SerializableF sym (PPC.PPCReg v) where
 instance SP.KnownVariant v => W4S.W4SerializableFC (PPC.PPCReg v) where
+
+instance SP.KnownVariant v =>  PEM.ExprFoldable sym (PPC.PPCReg v tp) where
+  foldExpr _ _ _ = return
+
+instance SP.KnownVariant v => PEM.ExprFoldableF sym (PPC.PPCReg v) where
+instance SP.KnownVariant v => (PEM.ExprFoldableFC (PPC.PPCReg v)) where
 
 instance PA.ValidArch PPC.PPC32 where
   type ArchConfigOpts PPC.PPC32 = ()

--- a/src/Pate/Arch.hs
+++ b/src/Pate/Arch.hs
@@ -126,6 +126,7 @@ import qualified What4.Expr.ArrayUpdateMap as AUM
 import qualified Data.Parameterized.TraversableF as TF
 import Data.Maybe
 import Pate.Memory
+import qualified Pate.ExprMappable as PEM
 
 -- | The type of architecture-specific dedicated registers
 --
@@ -188,6 +189,7 @@ class
   , MCS.HasArchEndCase arch
   , Integral (EEP.ElfWordType (MC.ArchAddrWidth arch))
   , W4S.W4SerializableFC (MC.ArchReg arch)
+  , PEM.ExprFoldableFC (MC.ArchReg arch)
   ) => ValidArch arch where
   
   type ArchConfigOpts arch

--- a/src/Pate/Equivalence.hs
+++ b/src/Pate/Equivalence.hs
@@ -389,8 +389,7 @@ instance W4S.SerializableExprs sym => W4S.W4Serializable sym (MemoryCondition sy
 memPreCondToPred ::
   forall sym arch v.
   IsSymInterface sym =>
-  MM.RegisterInfo (MM.ArchReg arch) =>
-  Typeable arch =>
+  PA.ValidArch arch =>
   sym ->
   SimScope sym arch v ->
   MemRegionEquality sym arch ->

--- a/src/Pate/Ground.hs
+++ b/src/Pate/Ground.hs
@@ -71,6 +71,7 @@ import qualified What4.Partial as W4P
 import qualified SemMC.Util as SU
 
 import qualified Pate.Panic as PP
+import qualified Control.Monad.IO.Class as IO
 
 -- | This module allows a model from What4 to be captured with respect to
 -- some expression-containing type. This is used to ground concrete counter-examples
@@ -216,7 +217,7 @@ integerToNat i
 ground ::
   forall sym a.
   PS.ValidSym sym =>
-  PEM.ExprMappable sym (a sym) =>
+  PEM.ExprFoldableIO sym (a sym) =>
   sym ->
   -- | stack region
   W4.SymNat sym ->
@@ -239,7 +240,7 @@ ground sym stackRegion mkinfo a = do
       Nothing -> do
         upd <- MapF.updatedValue <$> MapF.updateAtKey e (Just <$> mkinfo e) (\_ -> return $ MapF.Keep) (grndInfoMap gdata)
         return $ gdata { grndInfoMap = upd }
-  gdata <- PEM.foldExpr sym f' a initGround
+  gdata <- PEM.foldExprIO sym f' a initGround
   return $ Grounded a gdata
 
 -- trivial instance - grounded values should not be modified

--- a/src/Pate/MemCell.hs
+++ b/src/Pate/MemCell.hs
@@ -162,7 +162,7 @@ readMemCell sym mem cell@(MemCell{}) = do
 writeMemCell ::
   forall sym arch w.
   IsSymInterface sym =>
-  MC.RegisterInfo (MC.ArchReg arch) =>
+  PMT.MemTraceValidArch arch =>
   Typeable arch =>
   sym ->
   -- | write condition

--- a/src/Pate/Monad.hs
+++ b/src/Pate/Monad.hs
@@ -128,7 +128,7 @@ import qualified Data.Set as S
 import qualified Data.IORef as IO
 import qualified Data.Text as T
 import qualified Data.Time as TM
-import           Data.Kind ( Type )
+import           Data.Kind ( Type, Constraint )
 import           Data.Typeable
 import           Data.Default
 import           Data.String ( IsString(..) )

--- a/src/Pate/Monad/PairGraph.hs
+++ b/src/Pate/Monad/PairGraph.hs
@@ -64,7 +64,7 @@ import qualified Data.Map as Map
 import qualified Pate.Equivalence.Error as PEE
 import GHC.Stack (HasCallStack)
 import qualified Prettyprinter as PP
-
+import qualified What4.Interface as W4
 
 instance IsTraceNode (k :: l) "pg_trace" where
   type TraceNodeType k "pg_trace" = [String]

--- a/src/Pate/Pointer.hs
+++ b/src/Pate/Pointer.hs
@@ -41,6 +41,7 @@ import qualified What4.JSON as W4S
 import qualified Lang.Crucible.LLVM.MemModel as CLM
 import qualified Data.Aeson as JSON
 import Data.Aeson ((.=))
+import qualified Pate.ExprMappable as PEM
 
 
 newtype Pointer sym w = PointerC { unPtr :: (CLM.LLVMPtr sym w) }
@@ -113,3 +114,6 @@ instance W4S.SerializableExprs sym => W4S.W4Serializable sym (Pointer sym w) whe
     return $ JSON.object ["region" .= reg_v, "offset" .= off_v]
 
 instance W4S.SerializableExprs sym => W4S.W4SerializableF sym (Pointer sym) where
+
+instance PEM.ExprFoldable sym (Pointer sym w) where
+  foldExpr _sym f (Pointer reg1 off1) b = f (W4.natToIntegerPure reg1) b >>= f off1

--- a/src/Pate/Proof.hs
+++ b/src/Pate/Proof.hs
@@ -136,6 +136,8 @@ instance PEM.ExprMappable sym (InequivalenceResultSym arch sym) where
     <*> PEM.mapExpr sym f a3
     <*> pure a4
 
+instance PEM.ExprFoldableIO sym (InequivalenceResultSym arch sym) where
+
 -- | An 'InequivalenceResultSym' once it has been grounded to a particular
 -- model (representing the counter-example for an inequivalence proof)
 type InequivalenceResult arch = PG.Grounded (InequivalenceResultSym arch)

--- a/src/Pate/Proof/CounterExample.hs
+++ b/src/Pate/Proof/CounterExample.hs
@@ -106,7 +106,8 @@ getInequivalenceResult defaultReason pre post slice fn = do
     return $ groundResult { PF.ineqReason = reason }
 
 ground ::
-  PEM.ExprMappable sym (a sym) =>
+  forall sym arch a.
+  PEM.ExprFoldableIO sym (a sym) =>
   SymGroundEvalFn sym ->
   a sym ->
   EquivM sym arch (PG.Grounded a)
@@ -173,7 +174,7 @@ getCondEquivalenceBindings eqCond fn = withValid $ do
 
 getGenPathCondition ::
   forall sym arch f.
-  PEM.ExprMappable sym f =>
+  (PEM.ExprMappable sym f, PEM.ExprFoldable sym f) =>
   SymGroundEvalFn sym ->
   f ->
   EquivM sym arch (W4.Pred sym)
@@ -194,7 +195,7 @@ getGenPathCondition fn f = withSym $ \sym -> do
 getGenPathConditionIO ::
   forall sym  t st fs f.
   sym ~ W4B.ExprBuilder t st fs =>
-  PEM.ExprMappable sym f =>
+  PEM.ExprFoldable sym f =>
   sym ->
   W4G.GroundEvalFn t ->
   (W4.Pred sym -> IO (Maybe Bool)) ->

--- a/src/Pate/SimState.hs
+++ b/src/Pate/SimState.hs
@@ -492,6 +492,9 @@ data ScopedExpr sym tp (v :: VarScope) =
 instance PEM.ExprMappable sym (ScopedExpr sym tp v) where
   mapExpr _sym f (ScopedExpr e) = ScopedExpr <$> f e
 
+instance PEM.ExprFoldable sym (ScopedExpr sym tp v) where
+  foldExpr _sym f (ScopedExpr e) = f e
+
 instance W4.IsExpr (W4.SymExpr sym) => PP.Pretty (ScopedExpr sym tp v) where
   pretty (ScopedExpr e) = W4.printSymExpr e
 
@@ -800,6 +803,14 @@ instance PEM.ExprMappable sym (SimState sym arch v bin) where
     <*> PEM.mapExpr sym f sb
     <*> PEM.mapExpr sym f scb
     <*> PEM.mapExpr sym f mr
+
+instance PEM.ExprFoldableF sym (MM.ArchReg arch) => PEM.ExprFoldable sym (SimState sym arch v bin) where
+  foldExpr sym f (SimState mem regs sb scb mr) b0 =
+        PEM.foldExpr sym f mem b0
+    >>= PEM.foldExpr sym f (MM.regStateMap regs)
+    >>= PEM.foldExpr sym f sb
+    >>= PEM.foldExpr sym f scb
+    >>= PEM.foldExpr sym f mr
 
 instance PEM.ExprMappable sym (SimInput sym arch v bin) where
   mapExpr sym f (SimInput st blk absSt) = SimInput

--- a/src/Pate/SimulatorRegisters.hs
+++ b/src/Pate/SimulatorRegisters.hs
@@ -140,3 +140,15 @@ instance PEM.ExprMappable sym (MacawRegEntry sym tp) where
         -- possible (an it isn't even a base type)
         return entry
       rep -> error ("mapExpr: unsupported macaw type " ++ show rep)
+
+instance PEM.ExprFoldable sym (MacawRegEntry sym tp) where
+  foldExpr _sym f entry b = do
+    case macawRegRepr entry of
+      CLM.LLVMPointerRepr{} -> do
+        let CLM.LLVMPointer reg off = macawRegValue entry
+        f (WI.natToIntegerPure reg) b >>= f off
+      CT.BoolRepr -> f (macawRegValue entry) b
+      CT.StructRepr Ctx.Empty -> return b
+      rep -> error ("foldExpr: unsupported macaw type " ++ show rep)
+
+instance forall sym. PEM.ExprFoldableF sym (MacawRegEntry sym)


### PR DESCRIPTION
ExprFoldableIO class falls back to the original behavior (i.e. using ExprMappable instance)